### PR TITLE
Restrict Google Drive Access to 'manga' Root Folder

### DIFF
--- a/GD-MangaReader/GD-MangaReader/App/Config.swift
+++ b/GD-MangaReader/GD-MangaReader/App/Config.swift
@@ -16,7 +16,12 @@ enum Config {
         static let scopes: [String] = [driveReadOnlyScope]
         
         /// デフォルトのmangaフォルダID（マイドライブ/manga）
+        /// 開発者メモ: これは開発者の環境個別のIDであるため、より汎用的にするには
+        /// "manga" という名前のフォルダをルートから検索するロジックが推奨される
         static let defaultFolderId: String? = "1MTQqHG1reKKgdt4iN5pECP5e6Oy-jv1s"
+        
+        /// ルートとするフォルダ名（このフォルダより上には行けない）
+        static let rootFolderName = "manga"
     }
     
     /// ローカルストレージ設定


### PR DESCRIPTION
This PR restricts the app's file navigation to a specific root folder named 'manga'.\n\n### Changes\n- Added 'manga' root folder configuration in Config.swift\n- Implemented root folder search and restriction logic in DriveService.swift\n- Updated LibraryViewModel to respect the root folder boundary\n\n### Security\n- Prevents users from navigating above the 'manga' folder to view other private files in Google Drive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Google Driveのルートフォルダ検出ロジックを改善し、より信頼性の高いフォルダ解決メカニズムを実装しました。
  * ナビゲーション時のフォルダID解決を強化し、フォルダが見つからない場合のエラーハンドリングを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->