### PR TITLE
feat: 作品一覧画面のフォルダアイコン上で内部のサムネイル（最大4冊分）を2x2構成でプレビュー表示する機能を追加

### DIFF
--- a/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
@@ -6,6 +6,40 @@
 import Foundation
 import SwiftUI
 
+/// 簡易的なLRUキャッシュ（Viewからの読み取りを安全に行うため、非破壊なsubscriptを提供）
+struct LRUCache<Key: Hashable, Value> {
+    private let capacity: Int
+    private var order: [Key] = []
+    private var dict: [Key: Value] = [:]
+    
+    init(capacity: Int) {
+        self.capacity = capacity
+    }
+    
+    mutating func set(_ value: Value, forKey key: Key) {
+        if let index = order.firstIndex(of: key) {
+            order.remove(at: index)
+        }
+        order.append(key)
+        dict[key] = value
+        
+        if order.count > capacity {
+            let oldest = order.removeFirst()
+            dict.removeValue(forKey: oldest)
+        }
+    }
+    
+    mutating func removeAll() {
+        dict.removeAll()
+        order.removeAll()
+    }
+    
+    // Viewバインディング用に非破壊な読み取りを提供（順序の更新は行わない）
+    subscript(key: Key) -> Value? {
+        dict[key]
+    }
+}
+
 /// ライブラリ（Driveファイルブラウザ）の状態管理
 @MainActor
 @Observable
@@ -26,8 +60,8 @@ final class LibraryViewModel {
     /// ダウンロード済みコミックのキャッシュ (DriveFileId -> LocalComic)
     private(set) var downloadedComics: [String: LocalComic] = [:]
     
-    /// フォルダのサムネイルURLキャッシュ (FolderId -> [URL]) (最大4つ)
-    private(set) var folderThumbnails: [String: [URL]] = [:]
+    /// フォルダのサムネイルURLキャッシュ (LRU管理, 上限500件)
+    private(set) var folderThumbnails = LRUCache<String, [URL]>(capacity: 500)
     
     /// 現在のフォルダID（nilはルート）
     private(set) var currentFolderId: String? = Config.GoogleAPI.defaultFolderId
@@ -127,6 +161,7 @@ final class LibraryViewModel {
     /// ファイル一覧を読み込み
     func loadFiles() async {
         refreshDownloadedComics()
+        folderThumbnails.removeAll()
         isLoading = true
         errorMessage = nil
         
@@ -186,12 +221,12 @@ final class LibraryViewModel {
             }
             
             // 4件に満たない場合でもキャッシュを確定して再フェッチを防ぐ
-            folderThumbnails[folder.id] = urls
+            folderThumbnails.set(urls, forKey: folder.id)
             
         } catch {
             print("Folder Thumbnail Fetch Array Error: \(folder.name) - \(error.localizedDescription)")
             // 失敗時は空配列を入れて無限リトライを防止
-            folderThumbnails[folder.id] = []
+            folderThumbnails.set([], forKey: folder.id)
         }
     }
     

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -464,7 +464,7 @@ struct DriveItemGridCell: View {
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 } else if item.isFolder, let folderThumbnails = folderThumbnails, !folderThumbnails.isEmpty {
                     // フォルダ用 サムネイルタイル
-                    FolderThumbnailView(urls: folderThumbnails, isGrid: true)
+                    FolderThumbnailView(urls: folderThumbnails)
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 } else {
                     Image(systemName: item.iconName)
@@ -557,7 +557,7 @@ struct DriveItemListRow: View {
                         .clipShape(Circle())
                 } else if item.isFolder, let folderThumbnails = folderThumbnails, !folderThumbnails.isEmpty {
                     // フォルダ用 サムネイルタイル
-                    FolderThumbnailView(urls: folderThumbnails, isGrid: false)
+                    FolderThumbnailView(urls: folderThumbnails)
                         .clipShape(Circle())
                 } else {
                     Image(systemName: item.iconName)
@@ -642,7 +642,6 @@ struct DriveItemListRow: View {
 /// フォルダ内の画像サムネイルを格子状に表示するビュー
 struct FolderThumbnailView: View {
     let urls: [URL]
-    let isGrid: Bool
     
     var body: some View {
         GeometryReader { geometry in


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * フォルダのサムネイル表示機能を追加しました。フォルダアイテムには最大4枚の候補画像がサムネイルグリッドで表示されます。
  * グリッドビューとリストビューの両方のレイアウトでサムネイル表示に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->