### PR TITLE
読書進捗の反映遅延解消と次巻おすすめ機能の追加

### DIFF
--- a/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
@@ -67,11 +67,17 @@ final class LibraryViewModel {
     
     /// ダウンロード済みコミックのキャッシュ (DriveFileId -> LocalComic)
     private(set) var downloadedComics: [String: LocalComic] = [:] {
-        didSet { updateRecentComics() }
+        didSet {
+            updateRecentComics()
+            updateNextRecommendedComics()
+        }
     }
     
     /// 最近読んだコミック（キャッシュから抽出して降順でソート、最大5件）
     private(set) var recentComics: [LocalComic] = []
+    
+    /// 次に読むべきおすすめ（最近読んだ作品の次巻など）
+    private(set) var nextRecommendedComics: [LocalComic] = []
     
     /// フォルダのサムネイルURLキャッシュ (LRU管理, 上限500件)
     private(set) var folderThumbnails = LRUCache<String, [URL]>(capacity: 500)
@@ -171,6 +177,68 @@ final class LibraryViewModel {
                 .sorted { ($0.lastReadAt ?? .distantPast) > ($1.lastReadAt ?? .distantPast) }
                 .prefix(5)
         )
+    }
+    
+    /// 次に読むべきおすすめを更新
+    private func updateNextRecommendedComics() {
+        let allComics = Array(downloadedComics.values)
+        guard !allComics.isEmpty else {
+            nextRecommendedComics = []
+            return
+        }
+        
+        // 最近読んだ順に数件のシリーズを対象にする
+        let recentlyRead = allComics
+            .filter { $0.lastReadAt != nil }
+            .sorted { ($0.lastReadAt ?? .distantPast) > ($1.lastReadAt ?? .distantPast) }
+            .prefix(5)
+            
+        var recommendations: [LocalComic] = []
+        var seenSeries = Set<String>()
+        
+        for comic in recentlyRead {
+            let seriesTitle = extractSeriesTitle(from: comic.title)
+            guard !seriesTitle.isEmpty && !seenSeries.contains(seriesTitle) else { continue }
+            seenSeries.insert(seriesTitle)
+            
+            // このシリーズの全巻を取得してソート
+            let seriesVolumes = allComics
+                .filter { extractSeriesTitle(from: $0.title) == seriesTitle }
+                .sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+            
+            // 現在の巻のインデックスを探す
+            if let currentIndex = seriesVolumes.firstIndex(where: { $0.id == comic.id }) {
+                // 次の巻があれば追加
+                if currentIndex + 1 < seriesVolumes.count {
+                    let nextVol = seriesVolumes[currentIndex + 1]
+                    // まだ読み終わっていない（進捗100%未満）ものを追加
+                    if nextVol.readingProgress < 0.95 {
+                        recommendations.append(nextVol)
+                    }
+                }
+            }
+        }
+        
+        nextRecommendedComics = recommendations
+    }
+    
+    /// タイトルからシリーズ名を抽出（巻数などを除去）
+    private func extractSeriesTitle(from title: String) -> String {
+        // 数字や巻数表記を簡易的に除去
+        let patterns = [
+            #"\s*[\(\[\{].*?[\)\]\}]$"#, // 末尾の括弧内を除去
+            #"\s*(?:vol\.?|#|第)?\s*\d+(?:\s*[巻回話])?.*$"# // 巻数表記を除去
+        ]
+        
+        var result = title
+        for pattern in patterns {
+            if let range = result.range(of: pattern, options: [.regularExpression, .caseInsensitive]) {
+                result = String(result[..<range.lowerBound])
+            }
+        }
+        
+        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? title : trimmed
     }
     
     /// DriveServiceに認証情報を設定

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -127,6 +127,11 @@ struct LibraryView: View {
                     localRefreshTrigger += 1
                 }
             }
+            .onChange(of: readingSession) { _, newValue in
+                if newValue == nil {
+                    libraryViewModel.refreshDownloadedComics()
+                }
+            }
             .sheet(item: $selectedItem) { item in
                 // ダウンロードターゲットを決定
                 let target: DownloadTarget = {
@@ -168,13 +173,25 @@ struct LibraryView: View {
     private var fileListContent: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                // 最近読んだ作品（ルート階層でのみ表示）
-                if libraryViewModel.folderPath.isEmpty && !libraryViewModel.recentComics.isEmpty {
-                    RecentComicsShelfView(
-                        readingSession: $readingSession,
-                        recentComics: libraryViewModel.recentComics
-                    )
-                    Divider().padding(.vertical, 8)
+                // 最近読んだ作品・おすすめ（ルート階層でのみ表示）
+                if libraryViewModel.folderPath.isEmpty {
+                    if !libraryViewModel.nextRecommendedComics.isEmpty {
+                        RecentComicsShelfView(
+                            title: "続きを読みませんか？",
+                            readingSession: $readingSession,
+                            recentComics: libraryViewModel.nextRecommendedComics
+                        )
+                        .padding(.bottom, 8)
+                    }
+                    
+                    if !libraryViewModel.recentComics.isEmpty {
+                        RecentComicsShelfView(
+                            title: "最近読んだ作品",
+                            readingSession: $readingSession,
+                            recentComics: libraryViewModel.recentComics
+                        )
+                        Divider().padding(.vertical, 8)
+                    }
                 }
                 
                 // パンくずリスト

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -19,9 +19,13 @@ struct LibraryView: View {
     @State private var localRefreshTrigger = 0
     @State private var toast: ToastData?
     
-    struct ComicSession: Identifiable {
+    struct ComicSession: Identifiable, Equatable {
         var id: String { source.id }
         let source: any ComicSource
+        
+        static func == (lhs: ComicSession, rhs: ComicSession) -> Bool {
+            lhs.id == rhs.id
+        }
     }
     
     private let gridColumns = [
@@ -30,138 +34,74 @@ struct LibraryView: View {
     
     var body: some View {
         NavigationStack {
-            ZStack {
-                // 背景
-                Color(.systemGroupedBackground)
-                    .ignoresSafeArea()
-                
-                if libraryViewModel.isLoading && libraryViewModel.items.isEmpty {
-                    // 初回ローディング
-                    shimmerLoadingView
-                } else if let error = libraryViewModel.errorMessage {
-                    // エラー表示
-                    errorView(message: error)
-                } else if libraryViewModel.items.isEmpty {
-                    // 空の状態
-                    emptyView
-                } else {
-                    // ファイル一覧
-                    fileListContent
-                }
-                
-                // 一括ダウンロードプログレスバナー
-                if bulkDownloadManager.isDownloading {
-                    VStack {
-                        Spacer()
-                        bulkDownloadBanner
-                    }
+            mainContent
+        }
+    }
+    
+    @ViewBuilder
+    private var mainContent: some View {
+        ZStack {
+            // 背景
+            Color(.systemGroupedBackground)
+                .ignoresSafeArea()
+            
+            contentLayer
+            
+            // 一括ダウンロードプログレスバナー
+            if bulkDownloadManager.isDownloading {
+                VStack {
+                    Spacer()
+                    bulkDownloadBanner
                 }
             }
-            .toastView(toast: $toast)
-            .navigationTitle(libraryViewModel.currentFolderName)
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar {
-                toolbarContent
+        }
+        .toastView(toast: $toast)
+        .navigationTitle(libraryViewModel.currentFolderName)
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            toolbarContent
+        }
+        .searchable(text: $libraryViewModel.searchText, prompt: "作品・フォルダを検索")
+        .refreshable {
+            await libraryViewModel.refresh()
+        }
+        .task {
+            libraryViewModel.configure(with: authViewModel.authorizer)
+            await libraryViewModel.loadFiles()
+        }
+        .onChange(of: selectedItem) { _, newValue in
+            if newValue == nil {
+                localRefreshTrigger += 1
             }
-            .searchable(text: $libraryViewModel.searchText, prompt: "作品・フォルダを検索")
-            .refreshable {
-                await libraryViewModel.refresh()
+        }
+        .onChange(of: readingSession) { _, newValue in
+            if newValue == nil {
+                libraryViewModel.refreshDownloadedComics()
             }
-            .task {
-                libraryViewModel.configure(with: authViewModel.authorizer)
-                await libraryViewModel.loadFiles()
-            }
-            .alert("サインアウト", isPresented: $showingSignOutAlert) {
-                Button("キャンセル", role: .cancel) {}
-                Button("サインアウト", role: .destructive) {
-                    authViewModel.signOut()
-                }
-            } message: {
-                Text("サインアウトしますか？")
-            }
-            .alert("シリーズ一括ダウンロード", isPresented: $showingBulkDownloadConfirmation) {
-                Button("キャンセル", role: .cancel) {}
-                Button("ダウンロード") {
-                    if let folder = selectedFolderForBulk {
-                        bulkDownloadManager.downloadSeries(
-                            folder: folder,
-                            driveService: libraryViewModel.driveService,
-                            authorizer: authViewModel.authorizer,
-                            accessToken: authViewModel.accessToken,
-                            onComplete: { failedCount in
-                                Task { @MainActor in
-                                    if failedCount == 0 {
-                                        toast = ToastData(
-                                            title: "ダウンロード完了",
-                                            message: "\(folder.name) のダウンロードが完了しました",
-                                            type: .success
-                                        )
-                                    } else {
-                                        let title = "ダウンロード完了 (\(failedCount)件失敗)"
-                                        let message = "\(folder.name) のダウンロードが完了しましたが、"
-                                            + "一部失敗しました"
-                                        toast = ToastData(title: title, message: message, type: .error)
-                                    }
-                                }
-                            },
-                            onError: { error in
-                                Task { @MainActor in
-                                    toast = ToastData(
-                                        title: "ダウンロード失敗",
-                                        message: error.localizedDescription,
-                                        type: .error
-                                    )
-                                }
-                            }
-                        )
-                        toast = ToastData(title: "ダウンロード開始", message: "\(folder.name) のダウンロードを開始しました", type: .info)
-                    }
-                }
-            } message: {
-                if let folder = selectedFolderForBulk {
-                    Text("\(folder.name)内のアーカイブを一括ダウンロードします。")
-                }
-            }
-            .onChange(of: selectedItem) { _, newValue in
-                if newValue == nil {
-                    localRefreshTrigger += 1
-                }
-            }
-            .onChange(of: readingSession) { _, newValue in
-                if newValue == nil {
-                    libraryViewModel.refreshDownloadedComics()
-                }
-            }
-            .sheet(item: $selectedItem) { item in
-                // ダウンロードターゲットを決定
-                let target: DownloadTarget = {
-                    if item.isArchive {
-                        return .file(item)
-                    } else {
-                        // 画像ファイルの場合は親フォルダをダウンロード
-                        return .folder(
-                            id: libraryViewModel.currentFolderId ?? "root",
-                            name: libraryViewModel.currentFolderName
-                        )
-                    }
-                }()
-                
-                DownloadSheet(
-                    target: target,
-                    isPresented: Binding(
-                        get: { self.selectedItem != nil },
-                        set: { if !$0 { self.selectedItem = nil } }
-                    ),
-                    onComplete: { comic in
-                        // ローカルコミックとして開く
-                        self.selectedItem = nil
-                        readingSession = ComicSession(source: LocalComicSource(comic: comic))
-                    }
-                )
-            }
-            .fullScreenCover(item: $readingSession) { session in
-                ReaderView(source: session.source)
-            }
+        }
+        .modifier(AlertsAndSheetsModifier(
+            showingSignOutAlert: $showingSignOutAlert,
+            showingBulkDownloadConfirmation: $showingBulkDownloadConfirmation,
+            selectedItem: $selectedItem,
+            selectedFolderForBulk: $selectedFolderForBulk,
+            readingSession: $readingSession,
+            toast: $toast,
+            authViewModel: authViewModel,
+            libraryViewModel: libraryViewModel,
+            bulkDownloadManager: bulkDownloadManager
+        ))
+    }
+    
+    @ViewBuilder
+    private var contentLayer: some View {
+        if libraryViewModel.isLoading && libraryViewModel.items.isEmpty {
+            shimmerLoadingView
+        } else if let error = libraryViewModel.errorMessage {
+            errorView(message: error)
+        } else if libraryViewModel.items.isEmpty {
+            emptyView
+        } else {
+            fileListContent
         }
     }
     
@@ -173,52 +113,14 @@ struct LibraryView: View {
     private var fileListContent: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                // 最近読んだ作品・おすすめ（ルート階層でのみ表示）
-                if libraryViewModel.folderPath.isEmpty {
-                    if !libraryViewModel.nextRecommendedComics.isEmpty {
-                        RecentComicsShelfView(
-                            title: "続きを読みませんか？",
-                            readingSession: $readingSession,
-                            recentComics: libraryViewModel.nextRecommendedComics
-                        )
-                        .padding(.bottom, 8)
-                    }
-                    
-                    if !libraryViewModel.recentComics.isEmpty {
-                        RecentComicsShelfView(
-                            title: "最近読んだ作品",
-                            readingSession: $readingSession,
-                            recentComics: libraryViewModel.recentComics
-                        )
-                        Divider().padding(.vertical, 8)
-                    }
-                }
+                recommendationSection
                 
                 // パンくずリスト
                 if !libraryViewModel.folderPath.isEmpty {
                     breadcrumbView
                 }
                 
-                // アイテム一覧
-                switch libraryViewModel.viewMode {
-                case .grid:
-                    DriveItemGridView(
-                        gridColumns: gridColumns,
-                        libraryViewModel: libraryViewModel,
-                        bulkDownloadManager: bulkDownloadManager,
-                        selectedFolderForBulk: $selectedFolderForBulk,
-                        showingBulkDownloadConfirmation: $showingBulkDownloadConfirmation,
-                        onItemTap: handleItemTap
-                    )
-                case .list:
-                    DriveItemListView(
-                        libraryViewModel: libraryViewModel,
-                        bulkDownloadManager: bulkDownloadManager,
-                        selectedFolderForBulk: $selectedFolderForBulk,
-                        showingBulkDownloadConfirmation: $showingBulkDownloadConfirmation,
-                        onItemTap: handleItemTap
-                    )
-                }
+                itemsSection
                 
                 // さらに読み込み
                 if libraryViewModel.hasMoreItems {
@@ -226,6 +128,54 @@ struct LibraryView: View {
                 }
             }
             .padding()
+        }
+    }
+    
+    /// おすすめセクション
+    @ViewBuilder
+    private var recommendationSection: some View {
+        if libraryViewModel.folderPath.isEmpty {
+            if !libraryViewModel.nextRecommendedComics.isEmpty {
+                RecentComicsShelfView(
+                    title: "続きを読みませんか？",
+                    readingSession: $readingSession,
+                    recentComics: libraryViewModel.nextRecommendedComics
+                )
+                .padding(.bottom, 8)
+            }
+            
+            if !libraryViewModel.recentComics.isEmpty {
+                RecentComicsShelfView(
+                    title: "最近読んだ作品",
+                    readingSession: $readingSession,
+                    recentComics: libraryViewModel.recentComics
+                )
+                Divider().padding(.vertical, 8)
+            }
+        }
+    }
+    
+    /// アイテム一覧セクション
+    @ViewBuilder
+    private var itemsSection: some View {
+        switch libraryViewModel.viewMode {
+        case .grid:
+            DriveItemGridView(
+                gridColumns: gridColumns,
+                libraryViewModel: libraryViewModel,
+                bulkDownloadManager: bulkDownloadManager,
+                selectedFolderForBulk: $selectedFolderForBulk,
+                showingBulkDownloadConfirmation: $showingBulkDownloadConfirmation,
+                onItemTap: handleItemTap
+            )
+        case .list:
+            DriveItemListView(
+                libraryViewModel: libraryViewModel,
+                bulkDownloadManager: bulkDownloadManager,
+                selectedFolderForBulk: $selectedFolderForBulk,
+                showingBulkDownloadConfirmation: $showingBulkDownloadConfirmation,
+                onItemTap: handleItemTap
+            )
         }
     }
     
@@ -701,3 +651,104 @@ struct FolderThumbnailView: View {
         .background(Color(.systemGray5))
     }
 }
+
+// MARK: - View Modifiers
+
+struct AlertsAndSheetsModifier: ViewModifier {
+    @Binding var showingSignOutAlert: Bool
+    @Binding var showingBulkDownloadConfirmation: Bool
+    @Binding var selectedItem: DriveItem?
+    @Binding var selectedFolderForBulk: DriveItem?
+    @Binding var readingSession: LibraryView.ComicSession?
+    @Binding var toast: ToastData?
+    
+    let authViewModel: AuthViewModel
+    let libraryViewModel: LibraryViewModel
+    let bulkDownloadManager: BulkDownloadManager
+    
+    func body(content: Content) -> some View {
+        content
+            .alert("サインアウト", isPresented: $showingSignOutAlert) {
+                Button("キャンセル", role: .cancel) {}
+                Button("サインアウト", role: .destructive) {
+                    authViewModel.signOut()
+                }
+            } message: {
+                Text("サインアウトしますか？")
+            }
+            .alert("シリーズ一括ダウンロード", isPresented: $showingBulkDownloadConfirmation) {
+                Button("キャンセル", role: .cancel) {}
+                Button("ダウンロード") {
+                    if let folder = selectedFolderForBulk {
+                        bulkDownloadManager.downloadSeries(
+                            folder: folder,
+                            driveService: libraryViewModel.driveService,
+                            authorizer: authViewModel.authorizer,
+                            accessToken: authViewModel.accessToken,
+                            onComplete: { failedCount in
+                                Task { @MainActor in
+                                    if failedCount == 0 {
+                                        toast = ToastData(
+                                            title: "ダウンロード完了",
+                                            message: "\(folder.name) のダウンロードが完了しました",
+                                            type: .success
+                                        )
+                                    } else {
+                                        let title = "ダウンロード完了 (\(failedCount)件失敗)"
+                                        let message = "\(folder.name) のダウンロードが完了しましたが、"
+                                            + "一部失敗しました"
+                                        toast = ToastData(title: title, message: message, type: .error)
+                                    }
+                                }
+                            },
+                            onError: { error in
+                                Task { @MainActor in
+                                    toast = ToastData(
+                                        title: "ダウンロード失敗",
+                                        message: error.localizedDescription,
+                                        type: .error
+                                    )
+                                }
+                            }
+                        )
+                        toast = ToastData(title: "ダウンロード開始", message: "\(folder.name) のダウンロードを開始しました", type: .info)
+                    }
+                }
+            } message: {
+                if let folder = selectedFolderForBulk {
+                    Text("\(folder.name)内のアーカイブを一括ダウンロードします。")
+                }
+            }
+            .sheet(item: $selectedItem) { item in
+                // ダウンロードターゲットを決定
+                let target: DownloadTarget = {
+                    if item.isArchive {
+                        return .file(item)
+                    } else {
+                        // 画像ファイルの場合は親フォルダをダウンロード
+                        return .folder(
+                            id: libraryViewModel.currentFolderId ?? "root",
+                            name: libraryViewModel.currentFolderName
+                        )
+                    }
+                }()
+                
+                DownloadSheet(
+                    target: target,
+                    isPresented: Binding(
+                        get: { self.selectedItem != nil },
+                        set: { if !$0 { self.selectedItem = nil } }
+                    ),
+                    onComplete: { comic in
+                        // ローカルコミックとして開く
+                        self.selectedItem = nil
+                        readingSession = LibraryView.ComicSession(source: LocalComicSource(comic: comic))
+                    }
+                )
+            }
+            .fullScreenCover(item: $readingSession) { session in
+                ReaderView(source: session.source)
+            }
+    }
+}
+

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -45,6 +45,9 @@ struct ReaderView: View {
             .onChange(of: geometry.size) { _, newSize in
                 viewModel.isLandscape = newSize.width > newSize.height
             }
+            .onChange(of: viewModel.currentPage) { _, _ in
+                saveProgress()
+            }
         }
         .ignoresSafeArea()
         .statusBarHidden(!viewModel.showUI)
@@ -178,8 +181,10 @@ struct ReaderView: View {
     private var headerBar: some View {
         HStack {
             Button {
-                saveProgress()
-                dismiss()
+                Task {
+                    await saveProgress()
+                    dismiss()
+                }
             } label: {
                 Image(systemName: "xmark")
                     .font(.title2)
@@ -346,9 +351,13 @@ struct ReaderView: View {
     
     // MARK: - Progress Save
     
+    private func saveProgress() async {
+        await source.saveProgress(page: viewModel.currentPage)
+    }
+    
     private func saveProgress() {
         Task {
-            await source.saveProgress(page: viewModel.currentPage)
+            await saveProgress()
         }
     }
 }

--- a/GD-MangaReader/GD-MangaReader/Views/RecentComicsShelfView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/RecentComicsShelfView.swift
@@ -2,12 +2,19 @@ import SwiftUI
 import Kingfisher
 
 struct RecentComicsShelfView: View {
+    let title: String
     @Binding var readingSession: LibraryView.ComicSession?
     let recentComics: [LocalComic]
     
+    init(title: String = "最近読んだ作品", readingSession: Binding<LibraryView.ComicSession?>, recentComics: [LocalComic]) {
+        self.title = title
+        self._readingSession = readingSession
+        self.recentComics = recentComics
+    }
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("最近読んだ作品")
+            Text(title)
                 .font(.headline)
                 .padding(.horizontal)
             


### PR DESCRIPTION
## 概要
- リーダー閲覧中の進捗がライブラリ画面で遅れて反映される問題を修正しました。
- 「最近読んだ作品」セクションの上に、ダウンロード済みの次巻を表示する「続きを読みませんか？」セクションを追加しました。
- LibraryView の View 構造を分割し、Swift コンパイラの型チェック負荷（ビルドタイムアウト）を軽減しました。

## 修正詳細
1. **進捗反映の最適化**: ReaderView でページ移動ごとに進捗を保存し、終了時に完了を待機するように変更。
2. **次巻おすすめロジック**: タイトルからシリーズ名を抽出する正規表現を実装し、未読の次巻を特定。
3. **リファクタリング**: LibraryView の複雑な View コンテンツとモディファイアを小規模なプロパティ・Modifier に分離。
4. **型修正**: ComicSession を Equatable に適合。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 最近読んだシリーズに基づいて次のおすすめコミックスを表示。

* **Improvements**
  * ライブラリビューのUI表示を最適化し、ローディング状態やエラー表示をより効率的に管理。
  * ページめくり時と終了時に進捗を自動で保存。
  * シェルフビューのタイトルをカスタマイズ可能に。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->