### PR TITLE
feat: 見開き表示のカスタマイズオプション追加とスライダーのバグ修正

### DIFF
--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -668,6 +668,17 @@ struct AlertsAndSheetsModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         content
+            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("OpenNextVolume"))) { notification in
+                if let nextComic = notification.object as? LocalComic {
+                    // 現在のセッションを一度閉じてから新しいセッションを開く
+                    readingSession = nil
+                    
+                    // わずかな遅延を入れて再表示（SwiftUIのシート遷移の制約のため）
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        readingSession = LibraryView.ComicSession(source: LocalComicSource(comic: nextComic))
+                    }
+                }
+            }
             .alert("サインアウト", isPresented: $showingSignOutAlert) {
                 Button("キャンセル", role: .cancel) {}
                 Button("サインアウト", role: .destructive) {

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -453,25 +453,44 @@ enum ReadingMode: String, CaseIterable {
 
 @Observable
 final class ReaderViewModel {
-    var currentPage: Int
+    var currentPage: Int {
+        didSet {
+            Task { @MainActor in
+                checkIfLastPageReached()
+            }
+        }
+    }
     var showUI: Bool = true
     var isRightToLeft: Bool = true
     var readingMode: ReadingMode = .horizontal
     var isSpreadEnabled: Bool = true {
-        didSet { currentPage = normalizePageIndex(currentPage) }
+        didSet { 
+            Task { @MainActor in
+                currentPage = normalizePageIndex(currentPage) 
+            }
+        }
     }
     var isSpreadSwapped: Bool = true
     var isSpreadShifted: Bool = true {
-        didSet { currentPage = normalizePageIndex(currentPage) }
+        didSet { 
+            Task { @MainActor in
+                currentPage = normalizePageIndex(currentPage) 
+            }
+        }
     }
     var isSpreadGapRemoved: Bool = true
     var isLandscape: Bool = false {
-        didSet { currentPage = normalizePageIndex(currentPage) }
+        didSet { 
+            Task { @MainActor in
+                currentPage = normalizePageIndex(currentPage) 
+            }
+        }
     }
     
     var showNextVolumeSuggestion: Bool = false
     private(set) var nextComic: LocalComic?
     private var checkNextVolumeTask: Task<Void, Never>?
+    private var suggestionTask: Task<Void, Never>?
     
     var isSpreadMode: Bool {
         return isSpreadEnabled && isLandscape
@@ -479,6 +498,7 @@ final class ReaderViewModel {
     
     private let source: any ComicSource
     
+    @MainActor
     init(source: any ComicSource) {
         self.source = source
         self.currentPage = source.lastReadPage
@@ -486,11 +506,14 @@ final class ReaderViewModel {
         // 次の巻があるか事前にチェック
         checkNextVolumeTask = Task {
             await checkForNextVolume()
+            // 初期表示で最終ページの場合に備える
+            checkIfLastPageReached()
         }
     }
     
     deinit {
         checkNextVolumeTask?.cancel()
+        suggestionTask?.cancel()
     }
     
     private func checkForNextVolume() async {
@@ -505,8 +528,10 @@ final class ReaderViewModel {
         if Task.isCancelled { return }
         
         // 同じシリーズと思われるものを抽出してソート
-        // 巻数サフィックス（例: " 第01巻"）を削除してベースタイトルを特定
-        let prefix = currentTitle.replacingOccurrences(of: "\\s*第\\d+巻$", with: "", options: .regularExpression)
+        // 巻数サフィックス（例: " 第01巻", " Vol.1", " (1)", " 01"）を削除してベースタイトルを特定
+        let pattern = "(\\s*第?\\d+[巻]?|\\s*Vol\\.?\\s*\\d+|\\s*\\(\\d+\\)|\\s+\\d+)$"
+        let prefix = currentTitle.replacingOccurrences(of: pattern, with: "", options: [.regularExpression, .caseInsensitive])
+        
         let seriesVolumes = allComics
             .filter { $0.title.hasPrefix(prefix) }
             .sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
@@ -515,7 +540,37 @@ final class ReaderViewModel {
         
         if let currentIndex = seriesVolumes.firstIndex(where: { $0.id == currentLocal.id }),
            currentIndex + 1 < seriesVolumes.count {
-            self.nextComic = seriesVolumes[currentIndex + 1]
+            await MainActor.run {
+                self.nextComic = seriesVolumes[currentIndex + 1]
+            }
+        }
+    }
+    
+    @MainActor
+    private func checkIfLastPageReached() {
+        suggestionTask?.cancel()
+        
+        // 次の巻がない、または最終ページでない場合は表示しない
+        guard let lastIndex = pageIndices.last,
+              currentPage == lastIndex,
+              nextComic != nil else {
+            showNextVolumeSuggestion = false
+            return
+        }
+        
+        // すでに表示されている場合は何もしない
+        if showNextVolumeSuggestion { return }
+        
+        // 1秒後にサジェストを表示
+        suggestionTask = Task {
+            try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
+            if !Task.isCancelled {
+                await MainActor.run {
+                    withAnimation(.easeInOut) {
+                        showNextVolumeSuggestion = true
+                    }
+                }
+            }
         }
     }
     
@@ -577,18 +632,24 @@ final class ReaderViewModel {
             
             // すでに最後のインデックスにいて、さらに次へ行こうとした場合
             if currentPage == nextPageIndex && nextComic != nil {
-                showNextVolumeSuggestion = true
+                withAnimation {
+                    showNextVolumeSuggestion = true
+                }
             } else {
                 currentPage = nextPageIndex
             }
         } else if nextComic != nil {
-            showNextVolumeSuggestion = true
+            withAnimation {
+                showNextVolumeSuggestion = true
+            }
         }
     }
     
     func goToPreviousPage() {
         if showNextVolumeSuggestion {
-            showNextVolumeSuggestion = false
+            withAnimation {
+                showNextVolumeSuggestion = false
+            }
             return
         }
         

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -384,11 +384,17 @@ final class ReaderViewModel {
     var showUI: Bool = true
     var isRightToLeft: Bool = true
     var readingMode: ReadingMode = .horizontal
-    var isSpreadEnabled: Bool = true
+    var isSpreadEnabled: Bool = true {
+        didSet { currentPage = normalizePageIndex(currentPage) }
+    }
     var isSpreadSwapped: Bool = false
-    var isSpreadShifted: Bool = false
+    var isSpreadShifted: Bool = false {
+        didSet { currentPage = normalizePageIndex(currentPage) }
+    }
     var isSpreadGapRemoved: Bool = false
-    var isLandscape: Bool = false
+    var isLandscape: Bool = false {
+        didSet { currentPage = normalizePageIndex(currentPage) }
+    }
     
     var isSpreadMode: Bool {
         return isSpreadEnabled && isLandscape

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -471,6 +471,7 @@ final class ReaderViewModel {
     
     var showNextVolumeSuggestion: Bool = false
     private(set) var nextComic: LocalComic?
+    private var checkNextVolumeTask: Task<Void, Never>?
     
     var isSpreadMode: Bool {
         return isSpreadEnabled && isLandscape
@@ -483,24 +484,34 @@ final class ReaderViewModel {
         self.currentPage = source.lastReadPage
         
         // 次の巻があるか事前にチェック
-        Task {
+        checkNextVolumeTask = Task {
             await checkForNextVolume()
         }
+    }
+    
+    deinit {
+        checkNextVolumeTask?.cancel()
     }
     
     private func checkForNextVolume() async {
         guard let currentLocal = source as? LocalComicSource else { return }
         let currentTitle = currentLocal.title
         
+        if Task.isCancelled { return }
+        
         // 全てのコミックを取得
         guard let allComics = try? LocalStorageService.shared.loadComics() else { return }
         
+        if Task.isCancelled { return }
+        
         // 同じシリーズと思われるものを抽出してソート
-        // 例: "漫画 第01巻", "漫画 第02巻" -> 接頭辞が一致するものを探す
-        let prefix = currentTitle.prefix(max(5, currentTitle.count - 5))
+        // 巻数サフィックス（例: " 第01巻"）を削除してベースタイトルを特定
+        let prefix = currentTitle.replacingOccurrences(of: "\\s*第\\d+巻$", with: "", options: .regularExpression)
         let seriesVolumes = allComics
             .filter { $0.title.hasPrefix(prefix) }
             .sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+        
+        if Task.isCancelled { return }
         
         if let currentIndex = seriesVolumes.firstIndex(where: { $0.id == currentLocal.id }),
            currentIndex + 1 < seriesVolumes.count {
@@ -541,14 +552,21 @@ final class ReaderViewModel {
     func normalizePageIndex(_ page: Int) -> Int {
         guard isSpreadMode else { return max(0, min(pageCount - 1, page)) }
         
+        let normalized: Int
         if !isSpreadShifted {
-            if page <= 0 { return 0 }
-            // 1, 2 -> 1 / 3, 4 -> 3 ... (奇数に丸める)
-            return ((page - 1) / 2) * 2 + 1
+            if page <= 0 {
+                normalized = 0
+            } else {
+                // 1, 2 -> 1 / 3, 4 -> 3 ... (奇数に丸める)
+                normalized = ((page - 1) / 2) * 2 + 1
+            }
         } else {
             // 0, 1 -> 0 / 2, 3 -> 2 ... (偶数に丸める)
-            return (page / 2) * 2
+            normalized = (page / 2) * 2
         }
+        
+        // 有効な範囲内にクランプ（pageCount - 1 を超えないようにする）
+        return max(0, min(normalized, pageCount - 1))
     }
     
     func goToNextPage() {

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -460,8 +460,8 @@ final class ReaderViewModel {
     var isSpreadEnabled: Bool = true {
         didSet { currentPage = normalizePageIndex(currentPage) }
     }
-    var isSpreadSwapped: Bool = false
-    var isSpreadShifted: Bool = false {
+    var isSpreadSwapped: Bool = true
+    var isSpreadShifted: Bool = true {
         didSet { currentPage = normalizePageIndex(currentPage) }
     }
     var isSpreadGapRemoved: Bool = true

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -35,6 +35,11 @@ struct ReaderView: View {
                 if viewModel.showUI {
                     uiOverlay
                 }
+                
+                // 次の巻サジェスト
+                if viewModel.showNextVolumeSuggestion, let nextComic = viewModel.nextComic {
+                    nextVolumeOverlay(nextComic: nextComic)
+                }
             }
             .onTapGesture(coordinateSpace: .local) { location in
                 handleTap(at: location, in: geometry.size)
@@ -367,6 +372,74 @@ struct ReaderView: View {
             await saveProgress()
         }
     }
+    
+    // MARK: - Next Volume Suggestion View
+    
+    private func nextVolumeOverlay(nextComic: LocalComic) -> some View {
+        ZStack {
+            Color.black.opacity(0.8).ignoresSafeArea()
+            
+            VStack(spacing: 24) {
+                Text("最終ページです")
+                    .font(.title3)
+                    .foregroundColor(.white.opacity(0.8))
+                
+                VStack(spacing: 8) {
+                    Text("次の巻を読みますか？")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                    
+                    Text(nextComic.title)
+                        .font(.subheadline)
+                        .foregroundColor(.orange)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+                
+                HStack(spacing: 20) {
+                    Button {
+                        viewModel.showNextVolumeSuggestion = false
+                    } label: {
+                        Text("閉じる")
+                            .foregroundColor(.white)
+                            .padding(.vertical, 12)
+                            .padding(.horizontal, 24)
+                            .background(Color.white.opacity(0.2))
+                            .cornerRadius(25)
+                    }
+                    
+                    Button {
+                        // 次の巻を開く
+                        // 実際には現在開いているReaderViewを閉じて、
+                        // 呼び出し元で次の巻のReaderViewを開く必要がある。
+                        // ここではNotificationCenterやDelegate等を使って親に通知する想定。
+                        NotificationCenter.default.post(
+                            name: Notification.Name("OpenNextVolume"),
+                            object: nextComic
+                        )
+                        dismiss()
+                    } label: {
+                        Text("次を読む")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .padding(.vertical, 12)
+                            .padding(.horizontal, 32)
+                            .background(Color.orange)
+                            .cornerRadius(25)
+                    }
+                }
+            }
+            .padding(32)
+            .background(Color(white: 0.1))
+            .cornerRadius(20)
+            .overlay(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(Color.white.opacity(0.1), lineWidth: 1)
+            )
+            .padding(20)
+        }
+        .transition(.opacity)
+    }
 }
 
 // MARK: - Reading Mode
@@ -391,10 +464,13 @@ final class ReaderViewModel {
     var isSpreadShifted: Bool = false {
         didSet { currentPage = normalizePageIndex(currentPage) }
     }
-    var isSpreadGapRemoved: Bool = false
+    var isSpreadGapRemoved: Bool = true
     var isLandscape: Bool = false {
         didSet { currentPage = normalizePageIndex(currentPage) }
     }
+    
+    var showNextVolumeSuggestion: Bool = false
+    private(set) var nextComic: LocalComic?
     
     var isSpreadMode: Bool {
         return isSpreadEnabled && isLandscape
@@ -405,6 +481,31 @@ final class ReaderViewModel {
     init(source: any ComicSource) {
         self.source = source
         self.currentPage = source.lastReadPage
+        
+        // 次の巻があるか事前にチェック
+        Task {
+            await checkForNextVolume()
+        }
+    }
+    
+    private func checkForNextVolume() async {
+        guard let currentLocal = source as? LocalComicSource else { return }
+        let currentTitle = currentLocal.title
+        
+        // 全てのコミックを取得
+        guard let allComics = try? LocalStorageService.shared.loadComics() else { return }
+        
+        // 同じシリーズと思われるものを抽出してソート
+        // 例: "漫画 第01巻", "漫画 第02巻" -> 接頭辞が一致するものを探す
+        let prefix = currentTitle.prefix(max(5, currentTitle.count - 5))
+        let seriesVolumes = allComics
+            .filter { $0.title.hasPrefix(prefix) }
+            .sorted { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+        
+        if let currentIndex = seriesVolumes.firstIndex(where: { $0.id == currentLocal.id }),
+           currentIndex + 1 < seriesVolumes.count {
+            self.nextComic = seriesVolumes[currentIndex + 1]
+        }
     }
     
     var pageCount: Int {
@@ -454,11 +555,25 @@ final class ReaderViewModel {
         if currentPage < pageCount - 1 {
             let currentIndex = pageIndices.firstIndex(of: currentPage) ?? 0
             let newIndex = min(pageIndices.count - 1, currentIndex + 1)
-            currentPage = pageIndices[newIndex]
+            let nextPageIndex = pageIndices[newIndex]
+            
+            // すでに最後のインデックスにいて、さらに次へ行こうとした場合
+            if currentPage == nextPageIndex && nextComic != nil {
+                showNextVolumeSuggestion = true
+            } else {
+                currentPage = nextPageIndex
+            }
+        } else if nextComic != nil {
+            showNextVolumeSuggestion = true
         }
     }
     
     func goToPreviousPage() {
+        if showNextVolumeSuggestion {
+            showNextVolumeSuggestion = false
+            return
+        }
+        
         if currentPage > 0 {
             let currentIndex = pageIndices.firstIndex(of: currentPage) ?? 0
             let newIndex = max(0, currentIndex - 1)

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -138,6 +138,7 @@ struct ReaderView: View {
                     index: leftIndex,
                     geometry: geometry,
                     isHalfWidth: true,
+                    alignment: viewModel.isSpreadGapRemoved ? .trailing : .center,
                     currentPage: viewModel.currentPage
                 )
             } else {
@@ -151,6 +152,7 @@ struct ReaderView: View {
                     index: rightIndex,
                     geometry: geometry,
                     isHalfWidth: true,
+                    alignment: viewModel.isSpreadGapRemoved ? .leading : .center,
                     currentPage: viewModel.currentPage
                 )
             } else {
@@ -237,6 +239,11 @@ struct ReaderView: View {
             if viewModel.isLandscape {
                 Section {
                     Toggle("見開き表示", isOn: $viewModel.isSpreadEnabled)
+                    if viewModel.isSpreadEnabled {
+                        Toggle("左右入れ替え", isOn: $viewModel.isSpreadSwapped)
+                        Toggle("半ページずらす", isOn: $viewModel.isSpreadShifted)
+                        Toggle("中央寄せ（空白除去）", isOn: $viewModel.isSpreadGapRemoved)
+                    }
                 }
             }
         } label: {
@@ -259,7 +266,7 @@ struct ReaderView: View {
                 Slider(
                     value: Binding(
                         get: { Double(viewModel.currentPage) },
-                        set: { viewModel.currentPage = Int($0) }
+                        set: { viewModel.currentPage = viewModel.normalizePageIndex(Int($0)) }
                     ),
                     in: 0...Double(max(0, source.pageCount - 1)),
                     step: 1
@@ -378,6 +385,9 @@ final class ReaderViewModel {
     var isRightToLeft: Bool = true
     var readingMode: ReadingMode = .horizontal
     var isSpreadEnabled: Bool = true
+    var isSpreadSwapped: Bool = false
+    var isSpreadShifted: Bool = false
+    var isSpreadGapRemoved: Bool = false
     var isLandscape: Bool = false
     
     var isSpreadMode: Bool {
@@ -401,9 +411,15 @@ final class ReaderViewModel {
     
     var pageIndices: [Int] {
         if isSpreadMode {
-            // 見開きモード：表紙（インデックス0）は単独、以降2ページずつ
-            var indices: [Int] = [0]
-            var current = 1
+            var indices: [Int] = []
+            var current = 0
+            
+            if !isSpreadShifted {
+                // 1ページ目（表紙）は単独
+                indices.append(0)
+                current = 1
+            }
+            
             while current < pageCount {
                 indices.append(current)
                 current += 2
@@ -411,6 +427,20 @@ final class ReaderViewModel {
             return indices
         } else {
             return Array(0..<pageCount)
+        }
+    }
+    
+    /// 任意のページ番号を、現在の表示モードにおける有効な開始インデックスに変換する
+    func normalizePageIndex(_ page: Int) -> Int {
+        guard isSpreadMode else { return max(0, min(pageCount - 1, page)) }
+        
+        if !isSpreadShifted {
+            if page <= 0 { return 0 }
+            // 1, 2 -> 1 / 3, 4 -> 3 ... (奇数に丸める)
+            return ((page - 1) / 2) * 2 + 1
+        } else {
+            // 0, 1 -> 0 / 2, 3 -> 2 ... (偶数に丸める)
+            return (page / 2) * 2
         }
     }
     
@@ -432,21 +462,44 @@ final class ReaderViewModel {
     
     /// 見開きページのインデックスを取得（左、右）
     func getSpreadIndices(for baseIndex: Int) -> (Int?, Int?) {
-        // 表紙（0）は常に単独で中央（右側に配置して左を空けるなど実装依存）
-        if baseIndex == 0 {
-            return (nil, 0)
+        if !isSpreadShifted && baseIndex == 0 {
+            // シフトなしの場合、0ページ目は単独
+            var left: Int?
+            var right: Int?
+            if isRightToLeft {
+                left = nil
+                right = 0
+            } else {
+                left = 0
+                right = nil
+            }
+            if isSpreadSwapped {
+                swap(&left, &right)
+            }
+            return (left, right)
         }
         
         let targetIndex = baseIndex
         let nextIndex = targetIndex + 1 < pageCount ? targetIndex + 1 : nil
         
+        var left: Int?
+        var right: Int?
+        
         if isRightToLeft {
             // 日本の漫画（右開き）：若い数字が右、次の数字が左
-            return (nextIndex, targetIndex)
+            left = nextIndex
+            right = targetIndex
         } else {
             // アメコミ等（左開き）：若い数字が左、次の数字が右
-            return (targetIndex, nextIndex)
+            left = targetIndex
+            right = nextIndex
         }
+        
+        if isSpreadSwapped {
+            swap(&left, &right)
+        }
+        
+        return (left, right)
     }
 }
 
@@ -457,6 +510,7 @@ struct ZoomableImageView: View {
     let index: Int
     let geometry: GeometryProxy
     var isHalfWidth: Bool = false
+    var alignment: Alignment = .center
     let currentPage: Int
     
     @State private var scale: CGFloat = 1.0
@@ -472,7 +526,7 @@ struct ZoomableImageView: View {
         
         AsyncImageView(source: source, index: index)
             .aspectRatio(contentMode: .fit)
-            .frame(width: imageWidth, height: geometry.size.height)
+            .frame(width: imageWidth, height: geometry.size.height, alignment: alignment)
             .clipped()
             .contentShape(Rectangle())
             .scaleEffect(scale)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 読書中に「次の巻サジェスト」オーバーレイを表示。閉じると非表示、「次を読む」で次巻を開く通知を発行し自動で次巻セッションに切替。

* **改善**
  * 見開き設定が拡張（左右入れ替え／半ページずらし／空白除去トグル）・画像の整列オプション追加。
  * ページスライダーと見開き索引を正規化してナビゲーション整合性を向上。サジェスト表示で最終見開きを超えない挙動に。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->