### PR TITLE
Fix ReaderView state management in next volume transitions

### DIFF
--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -835,6 +835,127 @@ struct AlertsAndSheetsModifier: ViewModifier {
     let authViewModel: AuthViewModel
     let libraryViewModel: LibraryViewModel
 
+    /// リーダーからの「次のDriveアイテムを開く」通知を処理する
+    private func handleOpenNextDriveItem(_ nextItem: DriveItem) {
+        // 現在のセッションを閉じる
+        readingSession = nil
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            if authViewModel.isOfflineMode {
+                openNextDriveItemOffline(nextItem)
+            } else {
+                openNextDriveItemOnline(nextItem)
+            }
+        }
+    }
+
+    /// オフラインモード時: ダウンロード済みアーカイブのみ開ける
+    private func openNextDriveItemOffline(_ nextItem: DriveItem) {
+        if nextItem.isArchive,
+           var existingComic = try? LocalStorageService.shared.findComic(byDriveFileId: nextItem.id),
+           existingComic.status == .completed {
+            // 次の巻は1ページ目から表示する
+            existingComic.lastReadPage = 0
+            readingSession = LibraryView.ComicSession(source: LocalComicSource(comic: existingComic))
+        } else {
+            // 未ダウンロードのアーカイブ、またはフォルダ/画像はオフライン表示不可
+            toast = ToastData(
+                title: "オフラインモード",
+                message: "この漫画はオフラインでは閲覧できません。",
+                type: .error
+            )
+        }
+    }
+
+    /// オンライン時: アイテムの種類に応じてソースを構築する
+    private func openNextDriveItemOnline(_ nextItem: DriveItem) {
+        if nextItem.isFolder {
+            openNextFolder(nextItem)
+        } else if nextItem.isImage {
+            openNextImage(nextItem)
+        } else if nextItem.isArchive {
+            openNextArchive(nextItem)
+        }
+    }
+
+    /// 次の巻がフォルダ（画像ストリーミング）の場合
+    private func openNextFolder(_ nextItem: DriveItem) {
+        // フォルダ内の画像一覧を取得してからソースを構築する
+        // （空のfilesを渡すとpageCount=0のまま固定されてしまうため）
+        Task { @MainActor in
+            var allItems: [DriveItem] = []
+            var token: String?
+            do {
+                repeat {
+                    let result = try await libraryViewModel.driveService.listFiles(
+                        in: nextItem.id,
+                        pageToken: token
+                    )
+                    allItems.append(contentsOf: result.items)
+                    token = result.nextPageToken
+                } while token != nil
+            } catch {
+                toast = ToastData(
+                    title: "読み込み失敗",
+                    message: error.localizedDescription,
+                    type: .error
+                )
+                return
+            }
+
+            let images = allItems.filter { $0.isImage }
+            guard !images.isEmpty else {
+                toast = ToastData(
+                    title: "ダウンロード",
+                    message: "この巻には画像が含まれていません",
+                    type: .error
+                )
+                return
+            }
+
+            // 取得中にユーザーが別のセッションを開始していた場合は、それを上書きしない
+            guard readingSession == nil else { return }
+
+            let source = RemoteComicSource(
+                folderId: nextItem.id,
+                title: nextItem.name,
+                files: images,
+                driveService: libraryViewModel.driveService,
+                parentId: libraryViewModel.currentFolderId
+            )
+            readingSession = LibraryView.ComicSession(source: source)
+        }
+    }
+
+    /// 次の巻が単独画像の場合
+    private func openNextImage(_ nextItem: DriveItem) {
+        // idは画像自身のものを使う（親フォルダIDを使うと、同じフォルダ内の
+        // 別画像へ連続ジャンプした際にidが変化せず、状態リセットも次巻検出も機能しなくなる）
+        let source = RemoteComicSource(
+            folderId: nextItem.id,
+            title: nextItem.name,
+            files: [nextItem],
+            driveService: libraryViewModel.driveService,
+            parentId: libraryViewModel.currentFolderId
+        )
+        readingSession = LibraryView.ComicSession(source: source)
+    }
+
+    /// 次の巻がアーカイブの場合
+    private func openNextArchive(_ nextItem: DriveItem) {
+        // アーカイブの場合はダウンロード済みかチェック
+        if var existingComic = try? LocalStorageService.shared.findComic(byDriveFileId: nextItem.id),
+           existingComic.status == .completed {
+            // 次の巻は1ページ目から表示する
+            existingComic.lastReadPage = 0
+            readingSession = LibraryView.ComicSession(source: LocalComicSource(comic: existingComic))
+        } else {
+            // 未ダウンロードの場合は、本来はDownloadSheetを出すべきだが
+            // リーダーからの自動遷移なので、一旦選択状態にする
+            selectedItem = nextItem
+        }
+    }
+
     func body(content: Content) -> some View {
         content
             .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("OpenNextVolume"))) { notification in
@@ -853,63 +974,7 @@ struct AlertsAndSheetsModifier: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("OpenNextDriveItem"))) { notification in
                 if let nextItem = notification.object as? DriveItem {
-                    // 現在のセッションを閉じる
-                    readingSession = nil
-                    
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                        if authViewModel.isOfflineMode {
-                            // オフラインモード時の制御
-                            if nextItem.isArchive,
-                               var existingComic = try? LocalStorageService.shared.findComic(byDriveFileId: nextItem.id),
-                               existingComic.status == .completed {
-                                // 次の巻は1ページ目から表示する
-                                existingComic.lastReadPage = 0
-                                readingSession = LibraryView.ComicSession(source: LocalComicSource(comic: existingComic))
-                            } else {
-                                // 未ダウンロードのアーカイブ、またはフォルダ/画像はオフライン表示不可
-                                toast = ToastData(
-                                    title: "オフラインモード",
-                                    message: "この漫画はオフラインでは閲覧できません。",
-                                    type: .error
-                                )
-                            }
-                        } else {
-                            // オンライン時の制御
-                            // 次の巻が画像（ストリーミング）の場合
-                            if nextItem.isFolder {
-                                let source = RemoteComicSource(
-                                    folderId: nextItem.id,
-                                    title: nextItem.name,
-                                    files: [], // 読み込み時にフェッチされるように RemoteComicSource側で対応が必要
-                                    driveService: libraryViewModel.driveService,
-                                    parentId: libraryViewModel.currentFolderId
-                                )
-                                readingSession = LibraryView.ComicSession(source: source)
-                            } else if nextItem.isImage {
-                                let folderId = nextItem.parentId ?? libraryViewModel.currentFolderId ?? ""
-                                let source = RemoteComicSource(
-                                    folderId: folderId,
-                                    title: nextItem.name,
-                                    files: [nextItem],
-                                    driveService: libraryViewModel.driveService,
-                                    parentId: libraryViewModel.currentFolderId
-                                )
-                                readingSession = LibraryView.ComicSession(source: source)
-                            } else if nextItem.isArchive {
-                                // アーカイブの場合はダウンロード済みかチェック
-                                if var existingComic = try? LocalStorageService.shared.findComic(byDriveFileId: nextItem.id),
-                                   existingComic.status == .completed {
-                                    // 次の巻は1ページ目から表示する
-                                    existingComic.lastReadPage = 0
-                                    readingSession = LibraryView.ComicSession(source: LocalComicSource(comic: existingComic))
-                                } else {
-                                    // 未ダウンロードの場合は、本来はDownloadSheetを出すべきだが
-                                    // リーダーからの自動遷移ので、一旦選択状態にする
-                                    selectedItem = nextItem
-                                }
-                            }
-                        }
-                    }
+                    handleOpenNextDriveItem(nextItem)
                 }
             }
             .alert("サインアウト", isPresented: $showingSignOutAlert) {
@@ -1029,7 +1094,12 @@ struct AlertsAndSheetsModifier: ViewModifier {
                 )
             }
             .fullScreenCover(item: $readingSession) { session in
+                // sessionのidが変わるたびにReaderViewとその@State（ReaderViewModel）を
+                // 強制的に作り直す。これがないと、次の巻への遷移がSwiftUI側で
+                // 「新規表示」ではなく「同一シートの内容差し替え」として扱われた場合に
+                // 古いReaderViewModel（＝古いページ数）が使い回されてしまう
                 ReaderView(source: session.source)
+                    .id(session.id)
             }
     }
 }

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -835,16 +835,30 @@ struct AlertsAndSheetsModifier: ViewModifier {
     let authViewModel: AuthViewModel
     let libraryViewModel: LibraryViewModel
 
+    /// 「次のDriveアイテムを開く」処理の最新リクエストを追跡するトークン
+    /// 0.6秒の遅延やフォルダ内一覧取得中に別の遷移リクエストが割り込んだ場合、
+    /// 古いリクエストがreadingSessionを上書きしてしまうのを防ぐために使う
+    @State private var pendingOpenNextDriveItemID: String?
+
     /// リーダーからの「次のDriveアイテムを開く」通知を処理する
     private func handleOpenNextDriveItem(_ nextItem: DriveItem) {
+        // 通知受信時点でリクエストIDと現在のフォルダIDをスナップショットする
+        // （遅延中にフォルダ移動やさらに新しい遷移が発生しても影響を受けないようにするため）
+        let requestID = nextItem.id
+        let parentId = libraryViewModel.currentFolderId
+        pendingOpenNextDriveItemID = requestID
+
         // 現在のセッションを閉じる
         readingSession = nil
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            // この間に別のリクエストが割り込んでいたら何もしない
+            guard pendingOpenNextDriveItemID == requestID, readingSession == nil else { return }
+
             if authViewModel.isOfflineMode {
                 openNextDriveItemOffline(nextItem)
             } else {
-                openNextDriveItemOnline(nextItem)
+                openNextDriveItemOnline(nextItem, requestID: requestID, parentId: parentId)
             }
         }
     }
@@ -868,18 +882,18 @@ struct AlertsAndSheetsModifier: ViewModifier {
     }
 
     /// オンライン時: アイテムの種類に応じてソースを構築する
-    private func openNextDriveItemOnline(_ nextItem: DriveItem) {
+    private func openNextDriveItemOnline(_ nextItem: DriveItem, requestID: String, parentId: String?) {
         if nextItem.isFolder {
-            openNextFolder(nextItem)
+            openNextFolder(nextItem, requestID: requestID, parentId: parentId)
         } else if nextItem.isImage {
-            openNextImage(nextItem)
+            openNextImage(nextItem, parentId: parentId)
         } else if nextItem.isArchive {
             openNextArchive(nextItem)
         }
     }
 
     /// 次の巻がフォルダ（画像ストリーミング）の場合
-    private func openNextFolder(_ nextItem: DriveItem) {
+    private func openNextFolder(_ nextItem: DriveItem, requestID: String, parentId: String?) {
         // フォルダ内の画像一覧を取得してからソースを構築する
         // （空のfilesを渡すとpageCount=0のまま固定されてしまうため）
         Task { @MainActor in
@@ -913,22 +927,22 @@ struct AlertsAndSheetsModifier: ViewModifier {
                 return
             }
 
-            // 取得中にユーザーが別のセッションを開始していた場合は、それを上書きしない
-            guard readingSession == nil else { return }
+            // 取得中に別の遷移リクエストが割り込んでいた場合は、それを上書きしない
+            guard pendingOpenNextDriveItemID == requestID, readingSession == nil else { return }
 
             let source = RemoteComicSource(
                 folderId: nextItem.id,
                 title: nextItem.name,
                 files: images,
                 driveService: libraryViewModel.driveService,
-                parentId: libraryViewModel.currentFolderId
+                parentId: parentId
             )
             readingSession = LibraryView.ComicSession(source: source)
         }
     }
 
     /// 次の巻が単独画像の場合
-    private func openNextImage(_ nextItem: DriveItem) {
+    private func openNextImage(_ nextItem: DriveItem, parentId: String?) {
         // idは画像自身のものを使う（親フォルダIDを使うと、同じフォルダ内の
         // 別画像へ連続ジャンプした際にidが変化せず、状態リセットも次巻検出も機能しなくなる）
         let source = RemoteComicSource(
@@ -936,7 +950,7 @@ struct AlertsAndSheetsModifier: ViewModifier {
             title: nextItem.name,
             files: [nextItem],
             driveService: libraryViewModel.driveService,
-            parentId: libraryViewModel.currentFolderId
+            parentId: parentId
         )
         readingSession = LibraryView.ComicSession(source: source)
     }

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -63,7 +63,6 @@ struct ReaderView: View {
                 viewModel.prefetchImages()
             }
         }
-        .id(source.id) // sourceが変わったらViewとStateを強制再生成
         .ignoresSafeArea()
         .statusBarHidden(!viewModel.showUI)
         .focusable()


### PR DESCRIPTION
## Summary

Fixes a critical bug in the next-volume chaining flow where:
1. Chaining next-volume suggestions (jump to next volume → read to end → jump again) failed frequently
2. If the source volume had fewer pages than the target volume, the reader would cap at the source's old page count in the new book

**Root cause:** `ReaderView`'s `@State private var viewModel` was initialized once and never discarded when transitioning between volumes. The view relied on a fragile, timing-dependent handoff in `LibraryView`'s notification handlers (`OpenNextVolume`/`OpenNextDriveItem`) — a hardcoded 0.6s delay to force re-presentation — but SwiftUI would sometimes treat rapid transitions as in-place content updates, leaving the stale `ReaderViewModel` and old page count alive. Additionally, `.id(source.id)` was placed on an inner `GeometryReader` rather than the `ReaderView` itself, rendering it ineffective.

**Fixes:**

1. **Correct `.id()` placement:** Moved `.id(session.id)` to the top level in `LibraryView`'s `.fullScreenCover` content closure (`ReaderView(source: session.source).id(session.id)`), ensuring SwiftUI deterministically tears down and recreates the view + state whenever the underlying comic changes.

2. **Removed misplaced `.id()`:** Deleted the now-redundant `.id(source.id)` from the inner `GeometryReader` in `ReaderView.swift`.

3. **Fixed RemoteComicSource construction bugs in `OpenNextDriveItem` handler:**
   - **Empty folder bug:** "Next volume is a folder" branch was passing `files: []`, pinning page count to 0. Now fetches the full paginated image listing via `driveService.listFiles()` before constructing the source, with error/empty-folder toasts.
   - **Single-image folder bug:** Was using `id = nextItem.parentId ?? currentFolderId` (parent's id) instead of the image's own id, defeating the state-reset fix and breaking `ReaderViewModel`'s own self-lookup. Fixed by using `nextItem.id`.

4. **Code organization:** Extracted `OpenNextDriveItem` handling from the inline `.onReceive` closure into `AlertsAndSheetsModifier.handleOpenNextDriveItem(_:)` plus helper methods (`openNextDriveItemOffline(_:)`, `openNextDriveItemOnline(_:)`, `openNextFolder(_:)`, `openNextImage(_:)`, `openNextArchive(_:)`), reducing cyclomatic complexity from 22 to under the 20-limit threshold.

5. **Async safety:** Added `guard readingSession == nil else { return }` in the Drive-fetch completion to prevent slow folder listing from overwriting a user's new selection.

## Test plan

- [x] Build succeeds: `xcodebuild build -sdk iphoneos -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` → BUILD SUCCEEDED
- [x] Linting clean: `swiftlint` → 0 serious violations
- [x] Smoke test on iOS Simulator: app launches cleanly, no crashes
- [ ] **Manual chained-volume testing (requires real Google account + downloaded comics):** Test the actual reported bug scenario — navigate to the last page of a comic, tap "read next volume," read that volume to the last page, tap "read next volume" again. Verify each transition completes cleanly and page counts are correct for each volume. *Note: This PR was verified via code review and static analysis in a sandboxed environment without access to real Google credentials or downloaded comics, so interactive manual verification of the chained-jump scenario is essential before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 次に開く項目の通知から、現在の閲覧を閉じたあとに次のコンテンツへスムーズに移動できるようになりました。
  * オフライン時とオンライン時で、開ける項目の扱いがより分かりやすくなりました。

* **バグ修正**
  * 閲覧中の画面が切り替わる際に、表示や状態が古いまま残る問題を改善しました。
  * フォルダ内の読み込み時に、途中で別の閲覧が始まっても誤って上書きしないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->