### PR TITLE
Replace folder thumbnails with persistent series cover cache

### DIFF
--- a/GD-MangaReader/GD-MangaReader/App/Config.swift
+++ b/GD-MangaReader/GD-MangaReader/App/Config.swift
@@ -3,6 +3,7 @@
 //
 // アプリケーション設定定数
 
+import CoreGraphics
 import Foundation
 
 /// アプリケーション設定
@@ -31,6 +32,12 @@ enum Config {
         
         /// 一時ファイル用ディレクトリ名
         static let tempDirectoryName = "Temp"
+
+        /// シリーズサムネイルキャッシュ用ディレクトリ名
+        static let seriesThumbnailsDirectoryName = "SeriesThumbnails"
+
+        /// シリーズサムネイルの生成先サイズ
+        static let seriesThumbnailTargetSize = CGSize(width: 400, height: 400)
     }
     
     /// サポートするファイル形式

--- a/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
+++ b/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
@@ -375,9 +375,10 @@ final class DownloadQueueManager {
     private func taskDidFinish(_ task: DownloadQueueTask) {
         onTaskFinished?(task)
 
-        if case .completed = task.state, let comic = task.comic {
-            Task { await maybeGenerateSeriesThumbnail(for: task, comic: comic) }
-        }
+        let thumbnailTask: Task<Void, Never>? = {
+            guard case .completed = task.state, let comic = task.comic else { return nil }
+            return Task { await maybeGenerateSeriesThumbnail(for: task, comic: comic) }
+        }()
 
         if pendingTasks.isEmpty {
             let completed = tasks.filter { $0.state == .completed }.count
@@ -385,8 +386,13 @@ final class DownloadQueueManager {
                 if case .failed = $0.state { return true }
                 return false
             }.count
-            endBackgroundTaskIfNeeded()
-            onQueueDrained?(completed, failed)
+            // サムネイル生成がバックグラウンド猶予時間の終了より先に完了するよう、
+            // 完了を待ってからバックグラウンドタスクを終了する
+            Task {
+                await thumbnailTask?.value
+                endBackgroundTaskIfNeeded()
+                onQueueDrained?(completed, failed)
+            }
         } else {
             processQueue()
         }

--- a/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
+++ b/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
@@ -125,6 +125,11 @@ final class DownloadQueueManager {
     /// キューが空になったときのコールバック（完了件数, 失敗件数）
     var onQueueDrained: ((_ completed: Int, _ failed: Int) -> Void)?
 
+    /// シリーズサムネイルが（ディスクへの書き込みまで完了して）更新されたときのコールバック
+    /// `onTaskFinished`はタスク完了と同時に同期的に発火するため、それより後に非同期で
+    /// 完了するサムネイル生成の通知には使えない。ここで生成完了を正確なタイミングで通知する
+    var onSeriesThumbnailUpdated: ((_ folderId: String) -> Void)?
+
     // MARK: - Computed Properties
 
     /// 未終了（待機中・実行中）のタスク
@@ -245,18 +250,7 @@ final class DownloadQueueManager {
     /// フォルダ内の全アーカイブをページングしながら取得し、名前順にソートして返す
     private func fetchAllArchives(inFolder folderId: String) async throws -> [DriveItem] {
         guard let driveService else { return [] }
-
-        var allItems: [DriveItem] = []
-        var token: String?
-        repeat {
-            let result = try await driveService.listFiles(in: folderId, pageToken: token)
-            allItems.append(contentsOf: result.items)
-            token = result.nextPageToken
-        } while token != nil
-
-        return allItems
-            .filter { $0.isArchive }
-            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+        return try await driveService.fetchArchivesNaturalSorted(inFolder: folderId)
     }
 
     // MARK: - Cancel / Clear
@@ -381,6 +375,10 @@ final class DownloadQueueManager {
     private func taskDidFinish(_ task: DownloadQueueTask) {
         onTaskFinished?(task)
 
+        if case .completed = task.state, let comic = task.comic {
+            Task { await maybeGenerateSeriesThumbnail(for: task, comic: comic) }
+        }
+
         if pendingTasks.isEmpty {
             let completed = tasks.filter { $0.state == .completed }.count
             let failed = tasks.filter {
@@ -391,6 +389,21 @@ final class DownloadQueueManager {
             onQueueDrained?(completed, failed)
         } else {
             processQueue()
+        }
+    }
+
+    /// ダウンロード完了したファイルがシリーズの1巻であれば、永続サムネイルを生成する
+    /// 既にキャッシュがある場合は何もしない（1巻が入れ替わるケースは非対応、全データ削除で再生成される）
+    private func maybeGenerateSeriesThumbnail(for task: DownloadQueueTask, comic: LocalComic) async {
+        guard case .file(let item) = task.target, let folderId = item.parentId else { return }
+        guard let firstImage = comic.imagePaths.first else { return }
+        guard SeriesThumbnailStore.shared.cachedThumbnailURL(forFolderId: folderId) == nil else { return }
+
+        guard let siblings = try? await driveService?.fetchArchivesNaturalSorted(inFolder: folderId),
+              siblings.first?.id == item.id else { return }
+
+        if await SeriesThumbnailStore.shared.generateThumbnail(forFolderId: folderId, imageURL: firstImage) != nil {
+            onSeriesThumbnailUpdated?(folderId)
         }
     }
 

--- a/GD-MangaReader/GD-MangaReader/Services/DriveService.swift
+++ b/GD-MangaReader/GD-MangaReader/Services/DriveService.swift
@@ -135,42 +135,25 @@ final class DriveService {
         return (items, result.nextPageToken)
     }
     
-    /// サムネイル制作用にフォルダ内の候補ファイル（アーカイブ/画像）を少数取得する
-    func fetchThumbnailCandidates(forFolder folderId: String, limit: Int = 4) async throws -> [DriveItem] {
-        let query = GTLRDriveQuery_FilesList.query()
-        
-        query.q = "'\(folderId)' in parents and trashed=false and (\(allExtensionQuery))"
-        // サムネイルに特化した必要最小限のフィールドだけを要求し軽量化
-        query.fields = "files(id, name, mimeType, thumbnailLink, imageMediaMetadata)"
-        query.orderBy = "name"
-        query.pageSize = limit
-        
-        let result = try await executeFileListQuery(query)
-        
-        let items = (result.files ?? []).compactMap { file -> DriveItem? in
-            guard let id = file.identifier, let name = file.name, let mimeType = file.mimeType else {
-                return nil
-            }
-            
-            return DriveItem(
-                id: id,
-                name: name,
-                mimeType: mimeType,
-                size: nil,
-                thumbnailURL: file.thumbnailLink.flatMap { URL(string: $0) },
-                parentId: folderId,
-                createdTime: file.createdTime?.date,
-                modifiedTime: file.modifiedTime?.date,
-                width: file.imageMediaMetadata?.width?.intValue,
-                height: file.imageMediaMetadata?.height?.intValue
-            )
-        }
-        
-        return Array(items.prefix(limit))
+    /// フォルダ内のアーカイブを全件（ページングしながら）取得し、自然順（巻数を数値として比較）にソートして返す
+    /// Drive側の`orderBy=name`は単純な文字列比較のため「10巻」が「2巻」より前に来てしまうことがあり、
+    /// "1巻"を確実に特定する用途にはこちらを使う
+    func fetchArchivesNaturalSorted(inFolder folderId: String) async throws -> [DriveItem] {
+        var allItems: [DriveItem] = []
+        var token: String?
+        repeat {
+            let result = try await listFiles(in: folderId, pageToken: token)
+            allItems.append(contentsOf: result.items)
+            token = result.nextPageToken
+        } while token != nil
+
+        return allItems
+            .filter { $0.isArchive }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
-    
+
     // MARK: - Private Helpers
-    
+
     private var allExtensionQuery: String {
         let archiveConditions = Config.SupportedFormats.archiveExtensions
             .map { "name contains '.\($0)'" }

--- a/GD-MangaReader/GD-MangaReader/Services/SeriesThumbnailStore.swift
+++ b/GD-MangaReader/GD-MangaReader/Services/SeriesThumbnailStore.swift
@@ -1,0 +1,126 @@
+// SeriesThumbnailStore.swift
+// GD-MangaReader
+//
+// シリーズ（Driveフォルダ）ごとの永続サムネイルキャッシュ管理サービス
+
+import Foundation
+import UIKit
+
+/// シリーズ（Driveフォルダid）ごとに1巻の表紙サムネイルを永続保存するサービス
+/// シリーズ単位のディレクトリは存在しないため、Documents直下にフラットな専用ディレクトリを持ち、
+/// ファイル名にDriveフォルダidを使うことでシリーズと1:1対応させる
+final class SeriesThumbnailStore: @unchecked Sendable {
+    // MARK: - Singleton
+
+    static let shared = SeriesThumbnailStore()
+
+    // MARK: - Properties
+
+    /// Documentsディレクトリ
+    private var documentsDirectory: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+
+    /// シリーズサムネイル保存ディレクトリ
+    var directory: URL {
+        documentsDirectory.appendingPathComponent(Config.Storage.seriesThumbnailsDirectoryName)
+    }
+
+    private let fileManager = FileManager.default
+
+    /// ディレクトリ操作のスレッドセーフなアクセスのための再帰的ロック
+    /// (ストレージ全削除がバックグラウンドスレッドから、サムネイル生成がMainActorから
+    /// それぞれ非同期に走るため、`LocalStorageService`と同様の保護が必要)
+    private let lock = NSRecursiveLock()
+
+    // MARK: - Initialization
+
+    private init() {
+        lock.lock()
+        defer { lock.unlock() }
+        if !fileManager.fileExists(atPath: directory.path) {
+            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// 指定フォルダの既存キャッシュファイルURL（存在すれば）
+    func cachedThumbnailURL(forFolderId folderId: String) -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        let url = fileURL(forFolderId: folderId)
+        return fileManager.fileExists(atPath: url.path) ? url : nil
+    }
+
+    /// ローカル画像（1巻のページ1）から縮小JPEGを生成して保存する
+    /// デコード・ダウンサンプル・エンコードはメインスレッドを塞がないようオフロードする
+    @discardableResult
+    func generateThumbnail(forFolderId folderId: String, imageURL: URL) async -> URL? {
+        let jpegData: Data? = await Task.detached(priority: .utility) {
+            guard let downsampled = UIImage.downsampledImage(
+                from: imageURL,
+                to: Config.Storage.seriesThumbnailTargetSize
+            ) else {
+                return nil
+            }
+            return downsampled.jpegData(compressionQuality: 0.8)
+        }.value
+
+        guard let jpegData else { return nil }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        // removeAll()等でディレクトリが削除されている可能性があるため、書き込み前に再作成する
+        if !fileManager.fileExists(atPath: directory.path) {
+            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
+        let destination = fileURL(forFolderId: folderId)
+        do {
+            try jpegData.write(to: destination, options: .atomic)
+            return destination
+        } catch {
+            return nil
+        }
+    }
+
+    /// 指定フォルダのキャッシュを削除
+    func removeThumbnail(forFolderId folderId: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        try? fileManager.removeItem(at: fileURL(forFolderId: folderId))
+    }
+
+    /// 全キャッシュを削除
+    func removeAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        try? fileManager.removeItem(at: directory)
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    /// キャッシュディレクトリ全体の使用サイズ
+    func calculateStorageUsage() -> Int64 {
+        lock.lock()
+        defer { lock.unlock() }
+        var totalSize: Int64 = 0
+
+        if let enumerator = fileManager.enumerator(at: directory, includingPropertiesForKeys: [.fileSizeKey]) {
+            while let fileURL = enumerator.nextObject() as? URL {
+                if let size = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                    totalSize += Int64(size)
+                }
+            }
+        }
+
+        return totalSize
+    }
+
+    // MARK: - Helpers
+
+    private func fileURL(forFolderId folderId: String) -> URL {
+        directory.appendingPathComponent("\(folderId).jpg")
+    }
+}

--- a/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
@@ -329,8 +329,8 @@ final class LibraryViewModel {
             seriesThumbnails.set(firstVolume?.thumbnailURL, forKey: folder.id)
         } catch {
             print("Series Thumbnail Fetch Error: \(folder.name) - \(error.localizedDescription)")
-            // 失敗時はnilを入れて無限リトライを防止
-            seriesThumbnails.set(nil, forKey: folder.id)
+            // 一時的なネットワーク/API エラーの場合はキャッシュせず、次回の表示時に再試行させる
+            // （「1巻が存在しない/thumbnailURLがない」という確定結果のみnilでキャッシュする）
         }
     }
 
@@ -338,6 +338,12 @@ final class LibraryViewModel {
     /// 生成された際に、次回`resolveSeriesThumbnail`でそれを拾わせるため）
     func invalidateSeriesThumbnail(folderId: String) {
         seriesThumbnails.removeValue(forKey: folderId)
+    }
+
+    /// 全シリーズの前段キャッシュを無効化する（ストレージ全削除後、消したファイルのURLを
+    /// 表示に使い続けてしまわないようにするため）
+    func invalidateAllSeriesThumbnails() {
+        seriesThumbnails.removeAll()
     }
     
     /// 次のページを読み込み

--- a/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
@@ -33,6 +33,13 @@ struct LRUCache<Key: Hashable, Value> {
         dict.removeAll()
         order.removeAll()
     }
+
+    mutating func removeValue(forKey key: Key) {
+        if let index = order.firstIndex(of: key) {
+            order.remove(at: index)
+        }
+        dict.removeValue(forKey: key)
+    }
     
     // Viewバインディング用に非破壊な読み取りを提供（順序の更新は行わない）
     subscript(key: Key) -> Value? {
@@ -82,8 +89,10 @@ final class LibraryViewModel {
     /// 次に読むべきおすすめ（最近読んだ作品の次巻など）
     private(set) var nextRecommendedComics: [LocalComic] = []
     
-    /// フォルダのサムネイルURLキャッシュ (LRU管理, 上限500件)
-    private(set) var folderThumbnails = LRUCache<String, [URL]>(capacity: 500)
+    /// シリーズ（フォルダ）の永続サムネイルURL解決結果のメモリ前段キャッシュ (LRU管理, 上限500件)
+    /// 実体（ディスクキャッシュ）は`SeriesThumbnailStore`が保持し、これは毎スクロールでの
+    /// ディスクI/Oを避けるための前段に過ぎないため、`loadFiles()`等では破棄しない
+    private(set) var seriesThumbnails = LRUCache<String, URL?>(capacity: 500)
     
     /// 現在のフォルダID（nilはルート）
     private(set) var currentFolderId: String? = Config.GoogleAPI.defaultFolderId
@@ -253,7 +262,6 @@ final class LibraryViewModel {
     /// ファイル一覧を読み込み
     func loadFiles() async {
         refreshDownloadedComics()
-        folderThumbnails.removeAll()
         isLoading = true
         errorMessage = nil
         
@@ -303,36 +311,33 @@ final class LibraryViewModel {
         }
     }
     
-    /// フォルダ用のプレビューサムネイル（最大4件）を非同期取得してキャッシュする
-    func fetchThumbnails(for folder: DriveItem) async {
+    /// シリーズ（フォルダ）の永続サムネイルを解決する
+    /// ディスクキャッシュ（1巻ダウンロード時に生成済み）があればそれを、なければ
+    /// Driveの1巻候補（自然順で先頭）の低画質thumbnailLinkにフォールバックする
+    func resolveSeriesThumbnail(for folder: DriveItem) async {
         guard folder.isFolder else { return }
-        // 既にローカルキャッシュにのっていれば何もしない
-        guard folderThumbnails[folder.id] == nil else { return }
-        
-        do {
-            let candidates = try await driveService.fetchThumbnailCandidates(forFolder: folder.id, limit: 4)
-            var urls: [URL] = []
-            
-            for candidate in candidates {
-                // 1. ローカルに高画質キャッシュがあるか
-                if let localComic = downloadedComics[candidate.id],
-                   let firstImage = localComic.imagePaths.first {
-                    urls.append(firstImage)
-                }
-                // 2. DriveAPIによる低画質サムネイルがあるか
-                else if let thumb = candidate.thumbnailURL {
-                    urls.append(thumb)
-                }
-            }
-            
-            // 4件に満たない場合でもキャッシュを確定して再フェッチを防ぐ
-            folderThumbnails.set(urls, forKey: folder.id)
-            
-        } catch {
-            print("Folder Thumbnail Fetch Array Error: \(folder.name) - \(error.localizedDescription)")
-            // 失敗時は空配列を入れて無限リトライを防止
-            folderThumbnails.set([], forKey: folder.id)
+        // 既に前段キャッシュにのっていれば何もしない
+        guard seriesThumbnails[folder.id] == nil else { return }
+
+        if let diskURL = SeriesThumbnailStore.shared.cachedThumbnailURL(forFolderId: folder.id) {
+            seriesThumbnails.set(diskURL, forKey: folder.id)
+            return
         }
+
+        do {
+            let firstVolume = try await driveService.fetchArchivesNaturalSorted(inFolder: folder.id).first
+            seriesThumbnails.set(firstVolume?.thumbnailURL, forKey: folder.id)
+        } catch {
+            print("Series Thumbnail Fetch Error: \(folder.name) - \(error.localizedDescription)")
+            // 失敗時はnilを入れて無限リトライを防止
+            seriesThumbnails.set(nil, forKey: folder.id)
+        }
+    }
+
+    /// 指定フォルダの前段キャッシュを無効化する（ダウンロード完了で新しいディスクキャッシュが
+    /// 生成された際に、次回`resolveSeriesThumbnail`でそれを拾わせるため）
+    func invalidateSeriesThumbnail(folderId: String) {
+        seriesThumbnails.removeValue(forKey: folderId)
     }
     
     /// 次のページを読み込み

--- a/GD-MangaReader/GD-MangaReader/ViewModels/StorageViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/StorageViewModel.swift
@@ -103,6 +103,9 @@ final class StorageViewModel {
                 SeriesThumbnailStore.shared.removeAll()
             }.value
             await loadData()
+            // LibraryViewModelは別のビュー階層にあり直接参照できないため、
+            // 通知経由で前段キャッシュ（downloadedComics/seriesThumbnails）の無効化を伝える
+            NotificationCenter.default.post(name: Notification.Name("AllComicsDeleted"), object: nil)
         } catch {
             errorMessage = "全削除に失敗しました: \(error.localizedDescription)"
         }

--- a/GD-MangaReader/GD-MangaReader/ViewModels/StorageViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/StorageViewModel.swift
@@ -72,6 +72,7 @@ final class StorageViewModel {
                 
                 // サイズ順にソート
                 let sortedItems = items.sorted { $0.size > $1.size }
+                total += SeriesThumbnailStore.shared.calculateStorageUsage()
                 return (sortedItems, total)
             }.value
             
@@ -99,6 +100,7 @@ final class StorageViewModel {
         do {
             try await Task.detached {
                 try LocalStorageService.shared.clearAllComics()
+                SeriesThumbnailStore.shared.removeAll()
             }.value
             await loadData()
         } catch {

--- a/GD-MangaReader/GD-MangaReader/Views/DriveItemGridView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/DriveItemGridView.swift
@@ -19,11 +19,11 @@ struct DriveItemGridView: View {
                         ? downloadQueue.hasPendingTasks(inFolder: item.id)
                         : downloadQueue.isInQueue(driveFileId: item.id),
                     localComic: libraryViewModel.downloadedComics[item.id],
-                    folderThumbnails: libraryViewModel.folderThumbnails[item.id]
+                    seriesThumbnailURL: libraryViewModel.seriesThumbnails[item.id] ?? nil
                 )
                     .task {
                         if item.isFolder {
-                            await libraryViewModel.fetchThumbnails(for: item)
+                            await libraryViewModel.resolveSeriesThumbnail(for: item)
                         }
                     }
                     .onTapGesture {

--- a/GD-MangaReader/GD-MangaReader/Views/DriveItemListView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/DriveItemListView.swift
@@ -18,11 +18,11 @@ struct DriveItemListView: View {
                         ? downloadQueue.hasPendingTasks(inFolder: item.id)
                         : downloadQueue.isInQueue(driveFileId: item.id),
                     localComic: libraryViewModel.downloadedComics[item.id],
-                    folderThumbnails: libraryViewModel.folderThumbnails[item.id]
+                    seriesThumbnailURL: libraryViewModel.seriesThumbnails[item.id] ?? nil
                 )
                     .task {
                         if item.isFolder {
-                            await libraryViewModel.fetchThumbnails(for: item)
+                            await libraryViewModel.resolveSeriesThumbnail(for: item)
                         }
                     }
                     .onTapGesture {

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -82,6 +82,11 @@ struct LibraryView: View {
             downloadQueue.onTaskFinished = { _ in
                 libraryViewModel.refreshDownloadedComics()
             }
+            downloadQueue.onSeriesThumbnailUpdated = { folderId in
+                // 実際にディスクへのサムネイル生成が完了したタイミングで前段キャッシュを無効化し、
+                // 次回表示時に新しいファイルを拾わせる
+                libraryViewModel.invalidateSeriesThumbnail(folderId: folderId)
+            }
             downloadQueue.onQueueDrained = { completed, failed in
                 guard completed + failed > 0 else { return }
                 if failed == 0 {
@@ -589,12 +594,12 @@ struct DriveItemGridCell: View {
     let item: DriveItem
     let isBulkDownloading: Bool
     let localComic: LocalComic?
-    let folderThumbnails: [URL]?
-    
+    let seriesThumbnailURL: URL?
+
     private var isDownloaded: Bool { localComic != nil }
     private var localThumbnailURL: URL? { localComic?.imagePaths.first }
     private var readingProgress: Double { localComic?.readingProgress ?? 0.0 }
-    
+
     var body: some View {
         VStack(spacing: 8) {
             // サムネイル / アイコン
@@ -602,7 +607,7 @@ struct DriveItemGridCell: View {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(Color(.secondarySystemGroupedBackground))
                     .aspectRatio(1, contentMode: .fit)
-                
+
                 if let thumbnailURL = item.thumbnailURL {
                     KFImage(thumbnailURL)
                         .resizable()
@@ -613,9 +618,11 @@ struct DriveItemGridCell: View {
                         .resizable()
                         .scaledToFill()
                         .clipShape(RoundedRectangle(cornerRadius: 12))
-                } else if item.isFolder, let folderThumbnails = folderThumbnails, !folderThumbnails.isEmpty {
-                    // フォルダ用 サムネイルタイル
-                    FolderThumbnailView(urls: folderThumbnails)
+                } else if item.isFolder, let seriesThumbnailURL = seriesThumbnailURL {
+                    // シリーズ（1巻）の永続サムネイル
+                    KFImage(seriesThumbnailURL)
+                        .resizable()
+                        .scaledToFill()
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 } else {
                     Image(systemName: item.iconName)
@@ -686,12 +693,12 @@ struct DriveItemListRow: View {
     let item: DriveItem
     let isBulkDownloading: Bool
     let localComic: LocalComic?
-    let folderThumbnails: [URL]?
-    
+    let seriesThumbnailURL: URL?
+
     private var isDownloaded: Bool { localComic != nil }
     private var localThumbnailURL: URL? { localComic?.imagePaths.first }
     private var readingProgress: Double { localComic?.readingProgress ?? 0.0 }
-    
+
     var body: some View {
         HStack(spacing: 12) {
             // アイコン
@@ -699,16 +706,19 @@ struct DriveItemListRow: View {
                 Circle()
                     .fill(Color(.secondarySystemGroupedBackground))
                     .frame(width: 44, height: 44)
-                
+
                 if let localThumbnailURL = localThumbnailURL {
                     KFImage(localThumbnailURL)
                         .resizable()
                         .scaledToFill()
                         .frame(width: 44, height: 44)
                         .clipShape(Circle())
-                } else if item.isFolder, let folderThumbnails = folderThumbnails, !folderThumbnails.isEmpty {
-                    // フォルダ用 サムネイルタイル
-                    FolderThumbnailView(urls: folderThumbnails)
+                } else if item.isFolder, let seriesThumbnailURL = seriesThumbnailURL {
+                    // シリーズ（1巻）の永続サムネイル
+                    KFImage(seriesThumbnailURL)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 44, height: 44)
                         .clipShape(Circle())
                 } else {
                     Image(systemName: item.iconName)
@@ -786,37 +796,6 @@ struct DriveItemListRow: View {
 #Preview {
     LibraryView()
         .environment(AuthViewModel())
-}
-
-// MARK: - Folder Thumbnail View
-
-/// フォルダ内の画像サムネイルを格子状に表示するビュー
-struct FolderThumbnailView: View {
-    let urls: [URL]
-    
-    var body: some View {
-        GeometryReader { geometry in
-            let cols = 2
-            let spacing: CGFloat = 2
-            let totalSpacing = spacing * CGFloat(cols - 1)
-            let itemSize = (geometry.size.width - totalSpacing) / CGFloat(cols)
-            
-            LazyVGrid(columns: [
-                GridItem(.fixed(itemSize), spacing: spacing),
-                GridItem(.fixed(itemSize), spacing: spacing)
-            ], spacing: spacing) {
-                // 最大4つまで表示
-                ForEach(0..<min(urls.count, 4), id: \.self) { index in
-                    KFImage(urls[index])
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: itemSize, height: itemSize)
-                        .clipped()
-                }
-            }
-        }
-        .background(Color(.systemGray5))
-    }
 }
 
 // MARK: - View Modifiers

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -951,6 +951,12 @@ struct AlertsAndSheetsModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("AllComicsDeleted"))) { _ in
+                // ストレージ管理画面での全削除を反映する（downloadedComics/seriesThumbnailsの
+                // 前段キャッシュが削除済みファイルのURLを保持し続けないようにする）
+                libraryViewModel.refreshDownloadedComics()
+                libraryViewModel.invalidateAllSeriesThumbnails()
+            }
             .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("OpenNextVolume"))) { notification in
                 if var nextComic = notification.object as? LocalComic {
                     // 次の巻は1ページ目から表示する


### PR DESCRIPTION
## Summary

**Problem:** The series (Google Drive folder) thumbnail in the library screen was a 2x2 tile grid of up to 4 volumes, sourced from an ephemeral in-memory cache that was discarded on every navigation or pull-to-refresh. The grid was populated from Drive's `orderBy=name` query (plain lexical sort, not numeric-aware), so "Volume 1" was unreliably present — e.g., "Volume 10" sorts before "Volume 2". Users saw inconsistent, hard-to-predict folder previews that didn't survive app restarts.

**Solution:** Replaced it with a single persistent cover thumbnail — always Volume 1 specifically — cached to disk at `Documents/SeriesThumbnails/<Drive folder id>.jpg`. The cache survives app relaunches and isn't tied to navigation state.

**Key changes:**
- New `SeriesThumbnailStore` service: persists downsampled JPEG thumbnails per series, thread-safe (uses `NSRecursiveLock`), image processing offloaded to background via `Task.detached` to avoid main-thread blocking
- New `DriveService.fetchArchivesNaturalSorted(inFolder:)`: pages through a folder's full listing and sorts with `localizedStandardCompare` (numeric-aware), reliably identifies Volume 1; `DownloadQueueManager.fetchAllArchives` now delegates to this shared implementation (removed duplicate pagination+sort logic)
- `DownloadQueueManager.taskDidFinish` now triggers thumbnail generation on successful downloads (only for direct file downloads with known parent folder, skipped once a thumbnail exists for that series, only generates if just-completed download is confirmed to be Volume 1); fires `onSeriesThumbnailUpdated` callback once written to disk
- `LibraryViewModel`: replaced ephemeral `folderThumbnails`/`fetchThumbnails` with persistent `seriesThumbnails`/`resolveSeriesThumbnail` (disk cache first, falls back to Drive's low-res `thumbnailLink` if needed); new in-memory cache intentionally NOT cleared on navigation
- `LibraryView`: `DriveItemGridCell` and `DriveItemListRow` now render single `seriesThumbnailURL` via `KFImage` (removed `FolderThumbnailView` tile-grid component)
- `StorageViewModel`: total storage usage and "delete all downloaded data" now account for the thumbnail cache directory

**Known limitation (intentional):** Series already fully downloaded before this feature shipped won't get a persistent thumbnail until a new volume downloads for that series (no backfill migration pass exists). They'll show Drive's `thumbnailLink` fallback until then.

## Test plan

- [x] `xcodegen generate && xcodebuild build -sdk iphoneos -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` → **BUILD SUCCEEDED** (verified)
- [x] `swiftlint` → 0 serious violations (verified)
- [x] App smoke test on iOS Simulator → launches cleanly, no crash (verified)
- [ ] **Manual verification required:** Download a series' Volume 1 in the app, confirm the persistent cover thumbnail appears in the library grid/list, then kill and relaunch the app and confirm the thumbnail is still visible (survives restart). Note: actual Google Drive authentication and comic downloads not available in sandbox environment, so this must be verified against real content in integration/staging testing.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * シリーズごとのサムネイル表示に対応し、一覧画面で作品の表紙がより見やすくなりました。
  * サムネイルは保存され、次回以降の表示がより速くなります。

* **改善**
  * フォルダ内の作品表示順が自然な並びになるよう改善しました。
  * ストレージ使用量にサムネイル分も反映されるようになり、全削除時にまとめて消去されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->