### PR TITLE
Add trial reading feature for volume 1 sampling

### DIFF
--- a/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
+++ b/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
@@ -281,16 +281,43 @@ final class DownloadQueueManager {
 
         // 各シリーズの1巻（自然順で先頭のアーカイブ）を収集する
         // 個別シリーズの取得失敗・アーカイブ0件はスキップして続行する（部分成功を優先）
-        var firstVolumes: [DriveItem] = []
-        for folder in seriesFolders {
-            do {
-                if let first = try await driveService.fetchArchivesNaturalSorted(inFolder: folder.id).first {
-                    firstVolumes.append(first)
+        // Drive APIのレート制限を考慮し、同時実行数を制限した並行取得を行う
+        // （スライディングウィンドウ方式はReaderView.scanWidePagesと同じパターン）
+        let concurrencyLimit = 4
+        var firstVolumes: [DriveItem] = await withTaskGroup(of: DriveItem?.self) { group in
+            var iterator = seriesFolders.makeIterator()
+
+            func addLookupTask(for folder: DriveItem) {
+                group.addTask {
+                    do {
+                        return try await driveService.fetchArchivesNaturalSorted(inFolder: folder.id).first
+                    } catch {
+                        print("⚠️ [DownloadQueueManager] Trial volume lookup failed: \(folder.name) - \(error.localizedDescription)")
+                        return nil
+                    }
                 }
-            } catch {
-                print("⚠️ [DownloadQueueManager] Trial volume lookup failed: \(folder.name) - \(error.localizedDescription)")
             }
+
+            // 初期バッチを投入し、1件完了するごとに次を継続投入する
+            for _ in 0..<min(concurrencyLimit, seriesFolders.count) {
+                guard let folder = iterator.next() else { break }
+                addLookupTask(for: folder)
+            }
+
+            var results: [DriveItem] = []
+            for await result in group {
+                if let first = result {
+                    results.append(first)
+                }
+                if let folder = iterator.next() {
+                    addLookupTask(for: folder)
+                }
+            }
+            return results
         }
+
+        // 並行取得の完了順は不定のため、キューへの投入順が安定するよう名前順に揃える
+        firstVolumes.sort { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
 
         // ダウンロード済み・キュー済みのスキップはenqueue(items:)側で行われる
         let added = enqueue(items: firstVolumes)

--- a/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
+++ b/GD-MangaReader/GD-MangaReader/Services/DownloadQueueManager.swift
@@ -253,6 +253,50 @@ final class DownloadQueueManager {
         return try await driveService.fetchArchivesNaturalSorted(inFolder: folderId)
     }
 
+    /// 試し読みの一括登録が実行中かどうか（二重実行防止用、UIからの参照も可）
+    private(set) var isTrialEnqueueInProgress = false
+
+    /// 全シリーズ（ルート直下のフォルダ）の1巻をキューに追加（試し読み）
+    /// ルート直下に直接置かれたアーカイブはどのシリーズにも属さないため対象外
+    /// - Returns: (新規に追加した件数, 見つかったシリーズ数, 1巻が特定できたシリーズ数)
+    ///   candidateCountにより「全巻ダウンロード済み」と「アーカイブが1件も見つからなかった」を区別できる
+    func enqueueTrialVolumes() async throws -> (added: Int, seriesCount: Int, candidateCount: Int) {
+        guard !isTrialEnqueueInProgress else { return (0, 0, 0) }
+        isTrialEnqueueInProgress = true
+        defer { isTrialEnqueueInProgress = false }
+
+        guard let driveService else { return (0, 0, 0) }
+
+        // ルート("manga"フォルダ)直下を全件取得する
+        // 表示中のリストはページングで一部しか読み込まれていない場合があるため、必ず全件を取得する
+        var rootItems: [DriveItem] = []
+        var token: String?
+        repeat {
+            let result = try await driveService.listFiles(in: nil, pageToken: token)
+            rootItems.append(contentsOf: result.items)
+            token = result.nextPageToken
+        } while token != nil
+
+        let seriesFolders = rootItems.filter { $0.isFolder }
+
+        // 各シリーズの1巻（自然順で先頭のアーカイブ）を収集する
+        // 個別シリーズの取得失敗・アーカイブ0件はスキップして続行する（部分成功を優先）
+        var firstVolumes: [DriveItem] = []
+        for folder in seriesFolders {
+            do {
+                if let first = try await driveService.fetchArchivesNaturalSorted(inFolder: folder.id).first {
+                    firstVolumes.append(first)
+                }
+            } catch {
+                print("⚠️ [DownloadQueueManager] Trial volume lookup failed: \(folder.name) - \(error.localizedDescription)")
+            }
+        }
+
+        // ダウンロード済み・キュー済みのスキップはenqueue(items:)側で行われる
+        let added = enqueue(items: firstVolumes)
+        return (added, seriesFolders.count, firstVolumes.count)
+    }
+
     // MARK: - Cancel / Clear
 
     /// タスクをキャンセル

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -18,6 +18,7 @@ struct LibraryView: View {
     @State private var showingCascadeDownloadConfirmation = false
     @State private var selectedItemForCascade: DriveItem?
     @State private var showingDownloadQueue = false
+    @State private var showingTrialDownloadConfirmation = false
     @State private var localRefreshTrigger = 0
     @State private var toast: ToastData?
     @State private var loadTask: Task<Void, Never>?
@@ -129,6 +130,7 @@ struct LibraryView: View {
             selectedFolderForBulk: $selectedFolderForBulk,
             showingCascadeDownloadConfirmation: $showingCascadeDownloadConfirmation,
             selectedItemForCascade: $selectedItemForCascade,
+            showingTrialDownloadConfirmation: $showingTrialDownloadConfirmation,
             showingDownloadQueue: $showingDownloadQueue,
             readingSession: $readingSession,
             toast: $toast,
@@ -451,6 +453,15 @@ struct LibraryView: View {
                 
                 Divider()
 
+                // 試し読み（ルート表示時のみ）
+                if libraryViewModel.folderPath.isEmpty {
+                    Button {
+                        handleTrialDownload()
+                    } label: {
+                        Label("試し読み（全シリーズの1巻）", systemImage: "sparkles")
+                    }
+                }
+
                 // ダウンロード一覧
                 Button {
                     showingDownloadQueue = true
@@ -519,6 +530,20 @@ struct LibraryView: View {
         guard !blockIfOffline() else { return }
         selectedItemForCascade = item
         showingCascadeDownloadConfirmation = true
+    }
+
+    /// メニュー: 試し読み（全シリーズの1巻をダウンロード）の確認
+    private func handleTrialDownload() {
+        guard !blockIfOffline() else { return }
+        guard !downloadQueue.isTrialEnqueueInProgress else {
+            toast = ToastData(
+                title: "試し読みダウンロード",
+                message: "現在処理中です。しばらくお待ちください。",
+                type: .info
+            )
+            return
+        }
+        showingTrialDownloadConfirmation = true
     }
 
     private func handleItemTap(_ item: DriveItem) {
@@ -807,6 +832,7 @@ struct AlertsAndSheetsModifier: ViewModifier {
     @Binding var selectedFolderForBulk: DriveItem?
     @Binding var showingCascadeDownloadConfirmation: Bool
     @Binding var selectedItemForCascade: DriveItem?
+    @Binding var showingTrialDownloadConfirmation: Bool
     @Binding var showingDownloadQueue: Bool
     @Binding var readingSession: LibraryView.ComicSession?
     @Binding var toast: ToastData?
@@ -1061,6 +1087,50 @@ struct AlertsAndSheetsModifier: ViewModifier {
                 if let item = selectedItemForCascade {
                     Text("「\(item.name)」以降のアーカイブをバックグラウンドでダウンロードします。")
                 }
+            }
+            .alert("試し読みダウンロード", isPresented: $showingTrialDownloadConfirmation) {
+                Button("キャンセル", role: .cancel) {}
+                Button("ダウンロード") {
+                    Task { @MainActor in
+                        do {
+                            let (added, seriesCount, candidateCount) =
+                                try await DownloadQueueManager.shared.enqueueTrialVolumes()
+                            if added > 0 {
+                                toast = ToastData(
+                                    title: "ダウンロード開始",
+                                    message: "\(seriesCount)シリーズ中\(added)件の1巻をキューに追加しました",
+                                    type: .info
+                                )
+                            } else if candidateCount > 0 {
+                                toast = ToastData(
+                                    title: "ダウンロード",
+                                    message: "追加できるファイルがありません（ダウンロード済み）",
+                                    type: .info
+                                )
+                            } else if seriesCount > 0 {
+                                toast = ToastData(
+                                    title: "ダウンロード",
+                                    message: "対象のアーカイブが見つかりませんでした",
+                                    type: .error
+                                )
+                            } else {
+                                toast = ToastData(
+                                    title: "ダウンロード",
+                                    message: "シリーズフォルダが見つかりませんでした",
+                                    type: .info
+                                )
+                            }
+                        } catch {
+                            toast = ToastData(
+                                title: "ダウンロード失敗",
+                                message: error.localizedDescription,
+                                type: .error
+                            )
+                        }
+                    }
+                }
+            } message: {
+                Text("全シリーズの1巻をバックグラウンドで一括ダウンロードします。シリーズ数が多い場合は時間がかかることがあります。")
             }
             .sheet(isPresented: $showingDownloadQueue) {
                 DownloadQueueView()


### PR DESCRIPTION
## Summary

- Adds "試し読み（全シリーズの1巻）" (trial reading) button to the library toolbar menu, visible only at the root level
- Downloads volume 1 from every series sequentially, allowing users to sample their entire library without full downloads
- Leverages existing queue infrastructure (batch enqueue, background queue, progress banner, completion toast) for seamless integration

## Implementation Details

- **DownloadQueueManager**: New `enqueueTrialVolumes()` method that fully paginates the Drive root, filters to series folders, resolves each series' first volume via natural-sort `fetchArchivesNaturalSorted`, and batch-enqueues all found items; per-series failures are logged and skipped (partial success preferred); `isTrialEnqueueInProgress` flag guards re-entrancy
- **LibraryView**: Button handler gates via existing `blockIfOffline()`, shows in-progress toast if enqueue is running, and displays differentiated result toasts (N件開始 / all cached / no archives / no series / error)

## Test plan

- [ ] Button appears only at library root (not in subfolders)
- [ ] Offline mode blocks the action with existing offline toast
- [ ] Trial enqueue successfully adds exactly one volume per series (natural-sort first) to the download queue
- [ ] Already-downloaded volumes are correctly skipped with appropriate cached toast
- [ ] All enqueue types show correct completion toasts (count started / all cached / no archives / no series found / errors)
- [ ] Re-entering the button while enqueue is in-progress shows the in-progress toast and doesn't double-queue
- [ ] Manual verification on real device with Google Drive credentials to confirm end-to-end behavior with actual series folders

🧠 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ライブラリ画面に「試し読みダウンロード」機能を追加しました。
  * 各シリーズの先頭巻をまとめてキューに追加できるようになりました。
  * 進行中の重複実行を防ぎ、オフライン時は実行をブロックします。

* **改善**
  * 処理結果に応じて、追加件数や対象シリーズ数を通知できるようになりました。
  * 一部シリーズで失敗しても、他のシリーズの取得を継続するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->