### PR TITLE
fix: Wide thumbnail overflow in series grid

### DIFF
--- a/GD-MangaReader/GD-MangaReader/Services/SeriesThumbnailStore.swift
+++ b/GD-MangaReader/GD-MangaReader/Services/SeriesThumbnailStore.swift
@@ -4,6 +4,7 @@
 // シリーズ（Driveフォルダ）ごとの永続サムネイルキャッシュ管理サービス
 
 import Foundation
+import ImageIO
 import UIKit
 
 /// シリーズ（Driveフォルダid）ごとに1巻の表紙サムネイルを永続保存するサービス
@@ -54,17 +55,28 @@ final class SeriesThumbnailStore: @unchecked Sendable {
     }
 
     /// ローカル画像（1巻のページ1）から縮小JPEGを生成して保存する
+    /// 横長画像（見開きスキャン等）の場合は、左上を起点に1ページ分（左半分）を切り出して保存する
     /// デコード・ダウンサンプル・エンコードはメインスレッドを塞がないようオフロードする
     @discardableResult
     func generateThumbnail(forFolderId folderId: String, imageURL: URL) async -> URL? {
         let jpegData: Data? = await Task.detached(priority: .utility) {
-            guard let downsampled = UIImage.downsampledImage(
-                from: imageURL,
-                to: Config.Storage.seriesThumbnailTargetSize
-            ) else {
+            let targetSize = Config.Storage.seriesThumbnailTargetSize
+            let isWide = Self.isWideImage(at: imageURL)
+
+            // 横長の場合は切り出し後も目標解像度を保てるよう2倍サイズでデコードする
+            let decodeSize = isWide
+                ? CGSize(width: targetSize.width * 2, height: targetSize.height * 2)
+                : targetSize
+
+            guard var image = UIImage.downsampledImage(from: imageURL, to: decodeSize) else {
                 return nil
             }
-            return downsampled.jpegData(compressionQuality: 0.8)
+
+            if isWide, let cropped = Self.cropLeadingPage(of: image) {
+                image = cropped
+            }
+
+            return image.jpegData(compressionQuality: 0.8)
         }.value
 
         guard let jpegData else { return nil }
@@ -122,5 +134,34 @@ final class SeriesThumbnailStore: @unchecked Sendable {
 
     private func fileURL(forFolderId folderId: String) -> URL {
         directory.appendingPathComponent("\(folderId).jpg")
+    }
+
+    /// 画像が横長（見開き）かどうかをピクセル寸法だけで判定する（フルデコードはしない）
+    /// 閾値は`ComicSource`のisWidePageと同じ「幅 > 高さ × 1.2」
+    /// kCGImagePropertyPixelWidth/Heightは回転適用前の値のため、EXIF orientationが
+    /// 90度回転系（5〜8）の場合は幅と高さを入れ替えて表示上の寸法で判定する
+    /// （切り出しは回転適用後の画像に対して行うため、判定もそれに合わせる必要がある）
+    private static func isWideImage(at url: URL) -> Bool {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? CGFloat,
+              let height = properties[kCGImagePropertyPixelHeight] as? CGFloat else {
+            return false
+        }
+
+        let orientation = properties[kCGImagePropertyOrientation] as? UInt32 ?? 1
+        let isRotated90 = (5...8).contains(orientation)
+        let displayWidth = isRotated90 ? height : width
+        let displayHeight = isRotated90 ? width : height
+
+        return displayWidth > displayHeight * 1.2
+    }
+
+    /// 見開き画像から左上を起点に1ページ分（左半分）を切り出す
+    private static func cropLeadingPage(of image: UIImage) -> UIImage? {
+        guard let cgImage = image.cgImage else { return nil }
+        let rect = CGRect(x: 0, y: 0, width: cgImage.width / 2, height: cgImage.height)
+        guard let cropped = cgImage.cropping(to: rect) else { return nil }
+        return UIImage(cgImage: cropped)
     }
 }

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -628,61 +628,44 @@ struct DriveItemGridCell: View {
     var body: some View {
         VStack(spacing: 8) {
             // サムネイル / アイコン
-            ZStack {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color(.secondarySystemGroupedBackground))
-                    .aspectRatio(1, contentMode: .fit)
-
-                if let thumbnailURL = item.thumbnailURL {
-                    KFImage(thumbnailURL)
-                        .resizable()
-                        .scaledToFill()
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                } else if let localThumbnailURL = localThumbnailURL {
-                    KFImage(localThumbnailURL)
-                        .resizable()
-                        .scaledToFill()
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                } else if item.isFolder, let seriesThumbnailURL = seriesThumbnailURL {
-                    // シリーズ（1巻）の永続サムネイル
-                    KFImage(seriesThumbnailURL)
-                        .resizable()
-                        .scaledToFill()
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                } else {
-                    Image(systemName: item.iconName)
-                        .font(.system(size: 40))
-                        .foregroundColor(iconColor)
+            // 正方形の背景をレイアウトの基準とし、画像はoverlayで重ねてクリップする
+            // （scaledToFillはframe制約なしだと横長画像でレイアウトがセル外へ広がり、
+            //   隣のセルに被ってしまうため）
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemGroupedBackground))
+                .aspectRatio(1, contentMode: .fit)
+                .overlay {
+                    thumbnailContent
                 }
-                
-                // 読了プログレスバー
-                if isDownloaded && readingProgress > 0 {
-                    VStack {
-                        Spacer()
-                        ProgressView(value: readingProgress)
-                            .progressViewStyle(.linear)
-                            .tint(.blue)
-                            .background(Color.white.opacity(0.8))
+                .overlay {
+                    // 読了プログレスバー
+                    if isDownloaded && readingProgress > 0 {
+                        VStack {
+                            Spacer()
+                            ProgressView(value: readingProgress)
+                                .progressViewStyle(.linear)
+                                .tint(.blue)
+                                .background(Color.white.opacity(0.8))
+                        }
                     }
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
-            }
-            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-            .overlay(alignment: .topTrailing) {
-                if isBulkDownloading {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle(tint: .blue))
-                        .background(Circle().fill(.white).frame(width: 24, height: 24).shadow(radius: 2))
-                        .offset(x: 4, y: -4)
-                } else if isDownloaded {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.title3)
-                        .foregroundColor(.green)
-                        .background(Circle().fill(.white).frame(width: 18, height: 18))
-                        .offset(x: 4, y: -4)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                .overlay(alignment: .topTrailing) {
+                    if isBulkDownloading {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: .blue))
+                            .background(Circle().fill(.white).frame(width: 24, height: 24).shadow(radius: 2))
+                            .offset(x: 4, y: -4)
+                    } else if isDownloaded {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.title3)
+                            .foregroundColor(.green)
+                            .background(Circle().fill(.white).frame(width: 18, height: 18))
+                            .offset(x: 4, y: -4)
+                    }
                 }
-            }
-            
+
             // ファイル名
             Text(item.name)
                 .font(.caption)
@@ -698,7 +681,31 @@ struct DriveItemGridCell: View {
         }
         .padding(8)
     }
-    
+
+    /// サムネイル画像（優先順: ファイル自身のDriveサムネ → ローカル1ページ目 → シリーズサムネ → アイコン）
+    /// はみ出しのクリップは呼び出し側（正方形背景のoverlay + clipShape）で行う
+    @ViewBuilder
+    private var thumbnailContent: some View {
+        if let thumbnailURL = item.thumbnailURL {
+            KFImage(thumbnailURL)
+                .resizable()
+                .scaledToFill()
+        } else if let localThumbnailURL = localThumbnailURL {
+            KFImage(localThumbnailURL)
+                .resizable()
+                .scaledToFill()
+        } else if item.isFolder, let seriesThumbnailURL = seriesThumbnailURL {
+            // シリーズ（1巻）の永続サムネイル
+            KFImage(seriesThumbnailURL)
+                .resizable()
+                .scaledToFill()
+        } else {
+            Image(systemName: item.iconName)
+                .font(.system(size: 40))
+                .foregroundColor(iconColor)
+        }
+    }
+
     private var iconColor: Color {
         if item.isFolder {
             return .blue


### PR DESCRIPTION
## Summary

Fix UI bug where landscape/wide thumbnail images (e.g., two-page spread scans) overflow into neighboring series cells on the library grid.

- **View containment (LibraryView.swift)**: Restructured `DriveItemGridCell` so the square `RoundedRectangle` is the sole layout anchor; thumbnail and progress bar applied via overlay, then single container-level `clipShape` → `shadow`, badge overlay after clipping. Prevents ANY image aspect ratio from growing the cell layout.
- **Generation-side crop (SeriesThumbnailStore.swift)**: `generateThumbnail` now detects wide sources (width > height × 1.2), decodes at 2× target size, and crops to the left half (one page from top-left). EXIF orientation-aware to avoid mismatches on rotated sources.

## Known Limitation

Series thumbnails already persisted before this fix won't be regenerated with the new left-page crop (generation is skipped when cache exists). The view fix contains overflow, but stale thumbnails still render center-cropped. Users can clear downloaded data to force regeneration.

## Test Plan

- [ ] Build succeeds: `xcodebuild build -sdk iphoneos -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
- [ ] No lint issues: `swiftlint` from repo root
- [ ] iOS Simulator smoke test: app launches cleanly, no crash
- [ ] On device with a series whose volume-1 first page is a wide spread:
  - [ ] Grid cells remain square with no overlap into neighbors
  - [ ] Newly downloaded series thumbnail shows the left page of the spread
  - [ ] Existing series thumbnails are contained (no overflow) but may still be center-cropped until cache is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 見開き画像のサムネイルを自動で判定し、左ページを優先して表示するようになりました。
  * サムネイル生成時の画像処理が改善され、より適切なサイズで保存されます。

* **改善**
  * ライブラリ一覧のアイテム表示が整理され、サムネイル、進捗バー、状態バッジの見た目がより一貫しました。
  * サムネイルの表示優先順位を維持しつつ、表示構造を見直して安定性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->