### PR TITLE
feat: Implement direct jump to intermediate folders

### DIFF
--- a/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
@@ -411,6 +411,20 @@ final class LibraryViewModel {
         await loadFiles()
     }
     
+    /// 中間フォルダに直接ジャンプする
+    func navigateToIntermediateFolder(_ folder: DriveItem) async {
+        guard !isOfflineMode else { return }
+        guard let index = folderPath.firstIndex(where: { $0.id == folder.id }) else { return }
+
+        // 指定されたフォルダ以降のパスを削除
+        folderPath = Array(folderPath.prefix(through: index))
+
+        currentFolderId = folder.id
+        items = []
+        updateFilteredItems()
+        await loadFiles()
+    }
+
     /// リフレッシュ
     func refresh() async {
         await loadFiles()

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -247,7 +247,9 @@ struct LibraryView: View {
                         .foregroundColor(.secondary)
                     
                     Button(folder.name) {
-                        // TODO: 中間フォルダへの直接ジャンプ
+                        Task {
+                            await libraryViewModel.navigateToIntermediateFolder(folder)
+                        }
                     }
                     .font(.caption)
                     .lineLimit(1)


### PR DESCRIPTION
Implemented the ability to click on an intermediate folder in the breadcrumb navigation in `LibraryView` to jump directly to it, addressing the TODO.

---
*PR created automatically by Jules for task [10849829117824335867](https://jules.google.com/task/10849829117824335867) started by @miyatsuko10004*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * パンくずリストの中間フォルダをタップすると、そのフォルダへ直接移動できるようになりました。
  * 移動後は表示内容が更新され、該当フォルダのファイル一覧が読み込まれます。
* **バグ修正**
  * オフライン時は不要な遷移処理を行わないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->