### PR TITLE
🧪 Add unit tests for LocalComicSource isWidePage

### DIFF
--- a/GD-MangaReader/GD-MangaReaderTests/LocalComicSourceTests.swift
+++ b/GD-MangaReader/GD-MangaReaderTests/LocalComicSourceTests.swift
@@ -1,0 +1,161 @@
+//
+//  LocalComicSourceTests.swift
+//  GD-MangaReaderTests
+//
+
+import XCTest
+import CoreGraphics
+import UniformTypeIdentifiers
+import ImageIO
+@testable import GD_MangaReader
+
+final class LocalComicSourceTests: XCTestCase {
+
+    var testComicPath: String!
+    var testComicDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        testComicPath = "TestComic_" + UUID().uuidString
+        testComicDirectory = LocalStorageService.shared.comicsDirectory.appendingPathComponent(testComicPath)
+
+        // Create directory for dummy files
+        try FileManager.default.createDirectory(at: testComicDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        // Clean up dummy directory
+        if FileManager.default.fileExists(atPath: testComicDirectory.path) {
+            try FileManager.default.removeItem(at: testComicDirectory)
+        }
+
+        try super.tearDownWithError()
+    }
+
+    // Helper to create an actual image file with specified dimensions
+    private func createDummyImage(fileName: String, width: Int, height: Int) throws -> URL {
+        let fileURL = testComicDirectory.appendingPathComponent(fileName)
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+
+        guard let context = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace, bitmapInfo: bitmapInfo) else {
+            throw NSError(domain: "TestError", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to create CGContext"])
+        }
+
+        // Fill with dummy color
+        context.setFillColor(red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        guard let cgImage = context.makeImage() else {
+            throw NSError(domain: "TestError", code: 2, userInfo: [NSLocalizedDescriptionKey: "Failed to create CGImage"])
+        }
+
+        guard let destination = CGImageDestinationCreateWithURL(fileURL as CFURL, UTType.jpeg.identifier as CFString, 1, nil) else {
+            throw NSError(domain: "TestError", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create CGImageDestination"])
+        }
+
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw NSError(domain: "TestError", code: 4, userInfo: [NSLocalizedDescriptionKey: "Failed to finalize CGImageDestination"])
+        }
+
+        return fileURL
+    }
+
+    func testIsWidePage_OutOfBounds_ReturnsFalse() async throws {
+        let comic = LocalComic(
+            title: "Test Comic",
+            driveFileId: "test_drive_id",
+            localPath: testComicPath,
+            imageFileNames: ["1.jpg", "2.jpg"] // Only 2 items
+        )
+        let source = LocalComicSource(comic: comic)
+
+        // Act
+        let isWideNegative = await source.isWidePage(at: -1)
+        let isWideExceeds = await source.isWidePage(at: 2)
+
+        // Assert
+        XCTAssertFalse(isWideNegative, "Negative index should return false")
+        XCTAssertFalse(isWideExceeds, "Index >= count should return false")
+    }
+
+    func testIsWidePage_MissingFile_ReturnsFalse() async throws {
+        let comic = LocalComic(
+            title: "Test Comic",
+            driveFileId: "test_drive_id",
+            localPath: testComicPath,
+            imageFileNames: ["missing.jpg"] // File not on disk
+        )
+        let source = LocalComicSource(comic: comic)
+
+        // Act
+        let isWide = await source.isWidePage(at: 0)
+
+        // Assert
+        XCTAssertFalse(isWide, "Missing file should handle gracefully and return false")
+    }
+
+    func testIsWidePage_NormalPage_ReturnsFalse() async throws {
+        // Arrange
+        let _ = try createDummyImage(fileName: "normal.jpg", width: 1000, height: 1500)
+
+        let comic = LocalComic(
+            title: "Test Comic",
+            driveFileId: "test_drive_id",
+            localPath: testComicPath,
+            imageFileNames: ["normal.jpg"]
+        )
+        let source = LocalComicSource(comic: comic)
+
+        // Act
+        let isWide = await source.isWidePage(at: 0)
+
+        // Assert
+        XCTAssertFalse(isWide, "width=1000, height=1500 is a portrait image and should not be wide (1000 < 1500 * 1.2 = 1800)")
+    }
+
+    func testIsWidePage_WidePage_ReturnsTrue() async throws {
+        // Arrange
+        // Threshold: width > height * 1.2
+        // If height = 1000, threshold = 1200
+        // Width = 1201 > 1200
+        let _ = try createDummyImage(fileName: "wide.jpg", width: 1201, height: 1000)
+
+        let comic = LocalComic(
+            title: "Test Comic",
+            driveFileId: "test_drive_id",
+            localPath: testComicPath,
+            imageFileNames: ["wide.jpg"]
+        )
+        let source = LocalComicSource(comic: comic)
+
+        // Act
+        let isWide = await source.isWidePage(at: 0)
+
+        // Assert
+        XCTAssertTrue(isWide, "width=1201, height=1000 is wide enough (1201 > 1000 * 1.2 = 1200)")
+    }
+
+    func testIsWidePage_ExactThreshold_ReturnsFalse() async throws {
+        // Arrange
+        // Width strictly equal to threshold: 1200 == 1000 * 1.2
+        let _ = try createDummyImage(fileName: "exact.jpg", width: 1200, height: 1000)
+
+        let comic = LocalComic(
+            title: "Test Comic",
+            driveFileId: "test_drive_id",
+            localPath: testComicPath,
+            imageFileNames: ["exact.jpg"]
+        )
+        let source = LocalComicSource(comic: comic)
+
+        // Act
+        let isWide = await source.isWidePage(at: 0)
+
+        // Assert
+        XCTAssertFalse(isWide, "Strict inequality (>) means exactly 1.2 ratio should be false")
+    }
+}

--- a/GD-MangaReader/project.yml
+++ b/GD-MangaReader/project.yml
@@ -1,86 +1,95 @@
+---
 name: GD-MangaReader
 options:
   bundleIdPrefix: com.example
   deploymentTarget:
-    iOS: "17.0"
-  xcodeVersion: "15.0"
+    iOS: '17.0'
+  xcodeVersion: '15.0'
   createIntermediateGroups: true
   generateEmptyDirectories: true
-
 configFiles:
   Debug: Secrets.xcconfig
   Release: Secrets.xcconfig
-
 settings:
   base:
-    SWIFT_VERSION: "5"
-    ENABLE_USER_SCRIPT_SANDBOXING: NO
-
+    SWIFT_VERSION: '5'
+    ENABLE_USER_SCRIPT_SANDBOXING: false
 packages:
   GoogleSignIn:
     url: https://github.com/google/GoogleSignIn-iOS
     branch: main
   GoogleAPIClientForREST:
     url: https://github.com/google/google-api-objectivec-client-for-rest
-    from: "3.0.0"
+    from: 3.0.0
   ZIPFoundation:
     url: https://github.com/weichsel/ZIPFoundation
-    from: "0.9.0"
+    from: 0.9.0
   Kingfisher:
     url: https://github.com/onevcat/Kingfisher
-    from: "8.0.0"
-
+    from: 8.0.0
 targets:
   GD-MangaReader:
     type: application
     platform: iOS
     sources:
-      - path: GD-MangaReader
-        excludes:
-          - "**/.DS_Store"
+    - path: GD-MangaReader
+      excludes:
+      - "**/.DS_Store"
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.example.GD-MangaReader
         INFOPLIST_FILE: GD-MangaReader/Info.plist
-        DEVELOPMENT_TEAM: ""
+        DEVELOPMENT_TEAM: ''
         CODE_SIGN_STYLE: Automatic
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        TARGETED_DEVICE_FAMILY: "1,2"
-        SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: NO
+        TARGETED_DEVICE_FAMILY: '1,2'
+        SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: false
     dependencies:
-      - package: GoogleSignIn
-        product: GoogleSignIn
-      - package: GoogleSignIn
-        product: GoogleSignInSwift
-      - package: GoogleAPIClientForREST
-        product: GoogleAPIClientForREST_Drive
-      - package: ZIPFoundation
-      - package: Kingfisher
+    - package: GoogleSignIn
+      product: GoogleSignIn
+    - package: GoogleSignIn
+      product: GoogleSignInSwift
+    - package: GoogleAPIClientForREST
+      product: GoogleAPIClientForREST_Drive
+    - package: ZIPFoundation
+    - package: Kingfisher
     scheme: {}
     info:
       path: GD-MangaReader/Info.plist
       properties:
         CFBundleDisplayName: GD-MangaReader
-        CFBundleName: $(PRODUCT_NAME)
+        CFBundleName: "$(PRODUCT_NAME)"
         CFBundleIconName: AppIcon
-        CFBundleIdentifier: $(PRODUCT_BUNDLE_IDENTIFIER)
-        CFBundleVersion: "1"
-        CFBundleShortVersionString: "1.0"
-        CFBundleExecutable: $(EXECUTABLE_NAME)
-        CFBundlePackageType: $(PRODUCT_BUNDLE_PACKAGE_TYPE)
+        CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)"
+        CFBundleVersion: '1'
+        CFBundleShortVersionString: '1.0'
+        CFBundleExecutable: "$(EXECUTABLE_NAME)"
+        CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)"
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
-          - UIInterfaceOrientationPortrait
-          - UIInterfaceOrientationLandscapeLeft
-          - UIInterfaceOrientationLandscapeRight
+        - UIInterfaceOrientationPortrait
+        - UIInterfaceOrientationLandscapeLeft
+        - UIInterfaceOrientationLandscapeRight
         UISupportedInterfaceOrientations~ipad:
-          - UIInterfaceOrientationPortrait
-          - UIInterfaceOrientationPortraitUpsideDown
-          - UIInterfaceOrientationLandscapeLeft
-          - UIInterfaceOrientationLandscapeRight
+        - UIInterfaceOrientationPortrait
+        - UIInterfaceOrientationPortraitUpsideDown
+        - UIInterfaceOrientationLandscapeLeft
+        - UIInterfaceOrientationLandscapeRight
         CFBundleURLTypes:
-          - CFBundleURLSchemes:
-              - $(GID_REVERSED_CLIENT_ID)
-          - CFBundleURLSchemes:
-              - com.googleusercontent.apps.dummy
-        GIDClientID: $(GID_CLIENT_ID).apps.googleusercontent.com
+        - CFBundleURLSchemes:
+          - "$(GID_REVERSED_CLIENT_ID)"
+        - CFBundleURLSchemes:
+          - com.googleusercontent.apps.dummy
+        GIDClientID: "$(GID_CLIENT_ID).apps.googleusercontent.com"
+  GD-MangaReaderTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+    - GD-MangaReaderTests
+    dependencies:
+    - target: GD-MangaReader
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.GD-MangaReaderTests
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/GD-MangaReader.app/GD-MangaReader"
+        BUNDLE_LOADER: "$(TEST_HOST)"


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for `LocalComicSource.isWidePage`.

📊 **Coverage:** 
- The tests verify the aspect ratio logic (width > height * 1.2) for standard and wide pages using dynamically generated physical image files on disk.
- It also covers boundary scenarios (width == height * 1.2), out of bounds array indices, and missing file edge cases.

✨ **Result:** Improved test coverage for LocalComicSource making the behavior of `isWidePage` verified and predictable, preventing regression in wide page detection logic. The `project.yml` file was also updated to add the `GD-MangaReaderTests` target correctly using XcodeGen.

---
*PR created automatically by Jules for task [10129343969268330458](https://jules.google.com/task/10129343969268330458) started by @miyatsuko10004*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 画像の縦横比判定について、範囲外・未存在・閾値未満・閾値超え・閾値ちょうどの各ケースを検証するテストを追加しました。
  * 一時的なテストデータの作成と後片付けを行う仕組みを追加しました。

* **Chores**
  * アプリ設定の表記ゆれを整理し、全体の設定値を統一しました。
  * テスト用ターゲットの設定を追加し、テスト実行環境を整備しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->