### PR TITLE
⚡ Bolt: Optimize search by filtering before sorting in LibraryViewModel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-09 - Filter Before Sorting in LibraryViewModel
+**Learning:** Found a classic performance bottleneck where `items` are sorted first (O(N log N)) and then filtered by `searchText` (O(N)). When users type in a search box, doing this on every keystroke for large folders (like a root folder with hundreds/thousands of archives) can cause main thread hitching.
+**Action:** Filter the array first based on `searchText`, and only apply the expensive sort (`localizedStandardCompare`) on the resulting subset. This reduces the time complexity to O(N) + O(K log K) where K is the number of matched items, providing a measurable UI responsiveness boost when searching.

--- a/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
+++ b/GD-MangaReader/GD-MangaReader/ViewModels/LibraryViewModel.swift
@@ -165,19 +165,18 @@ final class LibraryViewModel {
     
     /// 最新のアイテム、検索テキスト、ソート順に応じたフィルタリング結果を更新
     private func updateFilteredItems() {
-        let sorted = items.sorted {
+        // 先に検索キーワードで絞り込むことで、ソート（O(N log N)処理）の対象件数を減らすパフォーマンス最適化
+        let targetItems = searchText.isEmpty
+            ? items
+            : items.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+
+        filteredItems = targetItems.sorted {
             switch sortOption {
             case .nameAsc: return $0.name.localizedStandardCompare($1.name) == .orderedAscending
             case .nameDesc: return $0.name.localizedStandardCompare($1.name) == .orderedDescending
             case .dateNewest: return ($0.createdTime ?? .distantPast) > ($1.createdTime ?? .distantPast)
             case .dateOldest: return ($0.createdTime ?? .distantPast) < ($1.createdTime ?? .distantPast)
             }
-        }
-        
-        if searchText.isEmpty {
-            filteredItems = sorted
-        } else {
-            filteredItems = sorted.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
         }
     }
     


### PR DESCRIPTION
💡 **What:** 
In `LibraryViewModel.swift`, the `updateFilteredItems` method was modified to filter the `items` array based on `searchText` *before* applying the sorting logic.

🎯 **Why:** 
Previously, the code sorted the entire array of items in the folder (which is an $O(N \log N)$ operation using string comparisons) and then filtered the result based on the search query ($O(N)$). When a user types in the search bar, this heavy sort runs on every keystroke. By filtering first, we only sort the much smaller subset of items that actually match the search term.

📊 **Impact:** 
Reduces the time complexity of the update operation from $O(N \log N)$ to $O(N) + O(K \log K)$, where $N$ is the total number of items and $K$ is the number of items that match the search text. This will noticeably improve UI responsiveness when searching through large folders.

🔬 **Measurement:** 
Load a folder with hundreds of archives, and quickly type characters into the search bar. The UI should no longer stutter or hitch during keystrokes.

---
*PR created automatically by Jules for task [3675108350691861590](https://jules.google.com/task/3675108350691861590) started by @miyatsuko10004*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 検索時の一覧更新を最適化し、該当項目だけを先に絞り込んでから並び替えるようにしました。
  * これにより、検索結果の表示がより軽快になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->