### PR TITLE
Googleドライブの命名規則に対応した漫画名の解析と表示フォーマット

### DIFF
--- a/GD-MangaReader/GD-MangaReader/Models/DriveItem.swift
+++ b/GD-MangaReader/GD-MangaReader/Models/DriveItem.swift
@@ -103,6 +103,78 @@ struct DriveItem: Identifiable, Hashable, Sendable {
     }
 }
 
+// MARK: - Display Name Parsing
+
+/// 「作品名[作者名]」（シリーズフォルダ）や「[作者名]作品名 第〇〇巻」（アーカイブ）形式の
+/// 名前を作品名・作者名・巻数に分解した表示用モデル
+struct MangaDisplayName: Hashable, Sendable {
+    /// 作品名（分解できない名前はそのまま全体が入る）
+    let title: String
+
+    /// 作者名（`[...]` が含まれない名前ではnil）
+    let author: String?
+
+    /// 巻数表記（例: "第01巻"）。含まれない名前ではnil
+    let volume: String?
+
+    /// 作品名の下に添える補足行（例: "第01巻 · 尾田栄一郎"）
+    var subtitle: String? {
+        let parts = [volume, author].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    init(parsing rawName: String) {
+        var working = rawName.trimmingCharacters(in: .whitespaces)
+        var author: String?
+
+        // 末尾の「[作者名]」（フォルダ形式）または先頭の「[作者名]」（アーカイブ形式）を抽出する。
+        // 末尾を先に判定するのは、「[HQ]鬼滅の刃[吾峠呼世晴]」のように両端にブラケットがある名前で
+        // 末尾の作者名タグを優先するため。アーカイブ名は（拡張子除去後）「第〇〇巻」で終わり
+        // 「]」で終わることはないので、この順序でアーカイブ形式の判定を妨げることはない。
+        // 作者名か残りの作品名が空になる場合は分解せず、名前全体を作品名として扱う
+        if working.hasSuffix("]"), let open = working.lastIndex(of: "[") {
+            let candidate = working[working.index(after: open)..<working.index(before: working.endIndex)]
+                .trimmingCharacters(in: .whitespaces)
+            let rest = working[..<open].trimmingCharacters(in: .whitespaces)
+            if !candidate.isEmpty && !rest.isEmpty {
+                author = candidate
+                working = rest
+            }
+        } else if working.hasPrefix("["), let close = working.firstIndex(of: "]") {
+            let candidate = working[working.index(after: working.startIndex)..<close]
+                .trimmingCharacters(in: .whitespaces)
+            let rest = working[working.index(after: close)...]
+                .trimmingCharacters(in: .whitespaces)
+            if !candidate.isEmpty && !rest.isEmpty {
+                author = candidate
+                working = rest
+            }
+        }
+
+        // 末尾の「第〇〇巻」を巻数として切り出す
+        var volume: String?
+        if let range = working.range(of: "第[0-9０-９]+巻$", options: .regularExpression) {
+            let rest = working[..<range.lowerBound].trimmingCharacters(in: .whitespaces)
+            if !rest.isEmpty {
+                volume = String(working[range])
+                working = rest
+            }
+        }
+
+        self.title = working
+        self.author = author
+        self.volume = volume
+    }
+}
+
+extension DriveItem {
+    /// 表示用に分解した名前（アーカイブは拡張子を除いてから解析する）
+    var displayName: MangaDisplayName {
+        let base = isArchive ? (name as NSString).deletingPathExtension : name
+        return MangaDisplayName(parsing: base)
+    }
+}
+
 // MARK: - LocalComic Extension
 
 extension DriveItem {

--- a/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/LibraryView.swift
@@ -668,12 +668,22 @@ struct DriveItemGridCell: View {
                     }
                 }
 
-            // ファイル名
-            Text(item.name)
-                .font(.caption)
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-            
+            // ファイル名（作品名と巻数・作者名を改行して表示）
+            // 補足行がないセルにも同じ高さを確保し、グリッド行の下端を揃える
+            let displayName = item.displayName
+            VStack(spacing: 2) {
+                Text(displayName.title)
+                    .font(.caption)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+
+                Text(displayName.subtitle ?? " ")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            .accessibilityElement(children: .combine)
+
             // サイズ
             if !item.isFolder {
                 Text(item.formattedSize)
@@ -776,12 +786,24 @@ struct DriveItemListRow: View {
                 }
             }
             
-            // ファイル情報
+            // ファイル情報（作品名と巻数・作者名を改行して表示）
+            let displayName = item.displayName
             VStack(alignment: .leading, spacing: 2) {
-                Text(item.name)
-                    .font(.body)
-                    .lineLimit(1)
-                
+                // タイトルと補足行はVoiceOverで1つの要素として読み上げる
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayName.title)
+                        .font(.body)
+                        .lineLimit(1)
+
+                    if let subtitle = displayName.subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+
                 if isDownloaded && readingProgress > 0 {
                     ProgressView(value: readingProgress)
                         .progressViewStyle(.linear)

--- a/GD-MangaReader/GD-MangaReader/Views/RecentComicsShelfView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/RecentComicsShelfView.swift
@@ -59,14 +59,25 @@ struct RecentComicsShelfView: View {
                                 }
                                 .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
                                 
-                                // タイトル
-                                Text(comic.title)
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                                    .foregroundColor(.primary)
-                                    .lineLimit(2)
-                                    .multilineTextAlignment(.leading)
-                                    .frame(width: 120, alignment: .leading)
+                                // タイトル（作品名と巻数・作者名を改行して表示）
+                                let displayName = MangaDisplayName(parsing: comic.title)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(displayName.title)
+                                        .font(.caption)
+                                        .fontWeight(.medium)
+                                        .foregroundColor(.primary)
+                                        .lineLimit(2)
+                                        .multilineTextAlignment(.leading)
+
+                                    if let subtitle = displayName.subtitle {
+                                        Text(subtitle)
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                }
+                                .accessibilityElement(children: .combine)
+                                .frame(width: 120, alignment: .leading)
                             }
                         }
                         .buttonStyle(PlainButtonStyle())

--- a/GD-MangaReader/GD-MangaReaderTests/MangaDisplayNameTests.swift
+++ b/GD-MangaReader/GD-MangaReaderTests/MangaDisplayNameTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import GD_MangaReader
+
+final class MangaDisplayNameTests: XCTestCase {
+
+    // MARK: - Folder format: 作品名[作者名]
+
+    func testParsing_FolderFormat_ExtractsTitleAndAuthor() {
+        let displayName = MangaDisplayName(parsing: "ワンピース[尾田栄一郎]")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+        XCTAssertNil(displayName.volume)
+    }
+
+    // MARK: - Both leading and trailing brackets
+
+    func testParsing_LeadingAndTrailingBrackets_PrefersTrailingAuthorTag() {
+        // Folder convention puts the author at the end; a leading tag like
+        // a release-group marker must stay part of the title.
+        let displayName = MangaDisplayName(parsing: "[HQ]鬼滅の刃[吾峠呼世晴]")
+
+        XCTAssertEqual(displayName.title, "[HQ]鬼滅の刃")
+        XCTAssertEqual(displayName.author, "吾峠呼世晴")
+        XCTAssertNil(displayName.volume)
+    }
+
+    func testParsing_LeadingBracketWithTrailingVolume_StillUsesLeadingAuthor() {
+        // Archive names end with 第〇〇巻 (never "]"), so the leading-bracket
+        // fallback must still handle the archive convention.
+        let displayName = MangaDisplayName(parsing: "[吾峠呼世晴]鬼滅の刃 第03巻")
+
+        XCTAssertEqual(displayName.title, "鬼滅の刃")
+        XCTAssertEqual(displayName.author, "吾峠呼世晴")
+        XCTAssertEqual(displayName.volume, "第03巻")
+    }
+
+    // MARK: - Archive format: [作者名]作品名 第〇〇巻
+
+    func testParsing_ArchiveFormat_ExtractsAuthorTitleAndVolume() {
+        let displayName = MangaDisplayName(parsing: "[尾田栄一郎]ワンピース 第01巻")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+        XCTAssertEqual(displayName.volume, "第01巻")
+    }
+
+    func testParsing_ArchiveFormat_FullWidthDigitsVolume() {
+        let displayName = MangaDisplayName(parsing: "[尾田栄一郎]ワンピース 第０１巻")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+        XCTAssertEqual(displayName.volume, "第０１巻")
+    }
+
+    func testParsing_ArchiveFormat_MultiDigitVolume() {
+        let displayName = MangaDisplayName(parsing: "[尾田栄一郎]ワンピース 第100巻")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+        XCTAssertEqual(displayName.volume, "第100巻")
+    }
+
+    func testParsing_ArchiveFormat_WithoutSpaceBeforeVolume() {
+        let displayName = MangaDisplayName(parsing: "[尾田栄一郎]ワンピース第01巻")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+        XCTAssertEqual(displayName.volume, "第01巻")
+    }
+
+    // MARK: - No brackets at all
+
+    func testParsing_NoBrackets_KeepsEntireStringAsTitle() {
+        let displayName = MangaDisplayName(parsing: "ワンピース")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertNil(displayName.author)
+        XCTAssertNil(displayName.volume)
+    }
+
+    func testParsing_NoBracketsButHasVolume_ExtractsTitleAndVolume() {
+        let displayName = MangaDisplayName(parsing: "ワンピース 第01巻")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertNil(displayName.author)
+        XCTAssertEqual(displayName.volume, "第01巻")
+    }
+
+    // MARK: - Bracket-only / empty-title edge cases
+
+    func testParsing_BracketOnly_DoesNotExtractAuthor() {
+        // Extracting author would leave an empty title, so the whole string
+        // should remain as the title instead.
+        let displayName = MangaDisplayName(parsing: "[作者名]")
+
+        XCTAssertEqual(displayName.title, "[作者名]")
+        XCTAssertNil(displayName.author)
+        XCTAssertNil(displayName.volume)
+    }
+
+    func testParsing_VolumeOnly_DoesNotExtractVolume() {
+        // Extracting the volume would leave an empty title, so the whole
+        // string should remain as the title instead.
+        let displayName = MangaDisplayName(parsing: "第01巻")
+
+        XCTAssertEqual(displayName.title, "第01巻")
+        XCTAssertNil(displayName.volume)
+        XCTAssertNil(displayName.author)
+    }
+
+    func testParsing_EmptyString_ResultsInEmptyTitle() {
+        let displayName = MangaDisplayName(parsing: "")
+
+        XCTAssertEqual(displayName.title, "")
+        XCTAssertNil(displayName.author)
+        XCTAssertNil(displayName.volume)
+    }
+
+    func testParsing_BracketsWithVolumeOnlyAfterAuthorRemoved_DoesNotExtractVolume() {
+        // After removing the author brackets, the remaining title is only
+        // the volume marker; volume extraction must be skipped to avoid an
+        // empty title.
+        let displayName = MangaDisplayName(parsing: "[作者名]第01巻")
+
+        XCTAssertEqual(displayName.title, "第01巻")
+        XCTAssertEqual(displayName.author, "作者名")
+        XCTAssertNil(displayName.volume)
+    }
+
+    // MARK: - Whitespace trimming
+
+    func testParsing_TrimsSurroundingWhitespace() {
+        let displayName = MangaDisplayName(parsing: "  ワンピース[尾田栄一郎]  ")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+    }
+
+    func testParsing_TrimsWhitespaceInsideBrackets() {
+        let displayName = MangaDisplayName(parsing: "ワンピース[ 尾田栄一郎 ]")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+    }
+
+    func testParsing_TrimsWhitespaceBetweenTitleAndVolume() {
+        let displayName = MangaDisplayName(parsing: "[尾田栄一郎]ワンピース   第01巻")
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.volume, "第01巻")
+    }
+
+    // MARK: - Subtitle composition
+
+    func testSubtitle_WithVolumeAndAuthor_JoinsBothWithMiddleDot() {
+        let displayName = MangaDisplayName(parsing: "[尾田栄一郎]ワンピース 第01巻")
+
+        XCTAssertEqual(displayName.subtitle, "第01巻 · 尾田栄一郎")
+    }
+
+    func testSubtitle_WithAuthorOnly_ReturnsAuthorOnly() {
+        let displayName = MangaDisplayName(parsing: "ワンピース[尾田栄一郎]")
+
+        XCTAssertEqual(displayName.subtitle, "尾田栄一郎")
+    }
+
+    func testSubtitle_WithVolumeOnly_ReturnsVolumeOnly() {
+        let displayName = MangaDisplayName(parsing: "ワンピース 第01巻")
+
+        XCTAssertEqual(displayName.subtitle, "第01巻")
+    }
+
+    func testSubtitle_WithNeitherVolumeNorAuthor_IsNil() {
+        let displayName = MangaDisplayName(parsing: "ワンピース")
+
+        XCTAssertNil(displayName.subtitle)
+    }
+
+    // MARK: - DriveItem.displayName extension stripping
+
+    func testDriveItemDisplayName_ArchiveStripsExtension() {
+        let item = DriveItem(
+            id: "file-1",
+            name: "[尾田栄一郎]ワンピース 第01巻.zip",
+            mimeType: "application/zip",
+            size: 1_000,
+            thumbnailURL: nil,
+            parentId: nil,
+            createdTime: nil,
+            modifiedTime: nil,
+            width: nil,
+            height: nil
+        )
+
+        let displayName = item.displayName
+
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+        XCTAssertEqual(displayName.volume, "第01巻")
+    }
+
+    func testDriveItemDisplayName_FolderKeepsRawNameUnstripped() {
+        let item = DriveItem(
+            id: "folder-1",
+            name: "ワンピース[尾田栄一郎]",
+            mimeType: "application/vnd.google-apps.folder",
+            size: nil,
+            thumbnailURL: nil,
+            parentId: nil,
+            createdTime: nil,
+            modifiedTime: nil,
+            width: nil,
+            height: nil
+        )
+
+        let displayName = item.displayName
+
+        // Folders have no path extension to strip; parsing should still work
+        // on the raw name.
+        XCTAssertEqual(displayName.title, "ワンピース")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+    }
+
+    func testDriveItemDisplayName_FolderWithDotInNameIsNotTreatedAsExtension() {
+        // A folder literally named with a trailing ".zip"-looking suffix
+        // should NOT have it stripped, since isArchive is false for folders.
+        let item = DriveItem(
+            id: "folder-2",
+            name: "ワンピース.zip[尾田栄一郎]",
+            mimeType: "application/vnd.google-apps.folder",
+            size: nil,
+            thumbnailURL: nil,
+            parentId: nil,
+            createdTime: nil,
+            modifiedTime: nil,
+            width: nil,
+            height: nil
+        )
+
+        let displayName = item.displayName
+
+        XCTAssertEqual(displayName.title, "ワンピース.zip")
+        XCTAssertEqual(displayName.author, "尾田栄一郎")
+    }
+}


### PR DESCRIPTION
## 概要
Google Drive の命名規則変更（シリーズフォルダは `作品名[作者名]`、ボリュームzipは `[作者名]作品名 第〇〇巻.zip`）に対応して、漫画の名前を解析し、読みやすい複数行ラベルとして表示するようにしました。

## 主な変更
- **DriveItem.swift**: 漫画名を `タイトル / 第〇〇巻 · 作者名` に分解する `MangaDisplayName` パーサー構造体を追加
- **LibraryView.swift**: グリッド表示とリスト表示の両方で、タイトルを1行目、「第〇〇巻 · 作者名」をサブタイトル行として表示
  - グリッドセルは常にサブタイトル行の高さを確保して行を統一
  - タイトル+サブタイトルを1つのVoiceOverラベルに統合
- **RecentComicsShelfView.swift**: 同じ2行フォーマットをシェルフタイルに適用
- **MangaDisplayNameTests.swift**: 23個のユニットテスト（すべてパス）

## 検証
- `xcodebuild build` 成功
- すべてのユニットテスト（23個）パス
- 命名規則に従わない名前は変更なしで表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 作品名をタイトル・作者名・巻数に分けて表示できるようになりました。
  * アーカイブの拡張子を除いた、読みやすい作品名を表示します。
  * ライブラリと最近読んだ作品の表示に、作者名や巻数の補足情報を追加しました。

* **アクセシビリティ**
  * 作品名と補足情報が、VoiceOverでまとめて読み上げられるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->