### PR TITLE
feat: 漫画の自動スクロール機能を追加

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,7 +2,7 @@ name: iOS Build
 
 on:
   push:
-    branches: [ "master", "feature/*" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Test
         run: |
           cd GD-MangaReader
-          xcodebuild test -scheme GD-MangaReader -project GD-MangaReader.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 15' CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}
+          xcodebuild test -scheme GD-MangaReader -project GD-MangaReader.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16' CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -297,6 +297,23 @@ struct ReaderView: View {
                 }
             }
             
+            Section("自動スクロール") {
+                Toggle("自動スクロール", isOn: Binding(
+                    get: { viewModel.isAutoScrollEnabled },
+                    set: { viewModel.isAutoScrollEnabled = $0 }
+                ))
+                if viewModel.isAutoScrollEnabled {
+                    Picker("間隔", selection: Binding(
+                        get: { viewModel.autoScrollInterval },
+                        set: { viewModel.autoScrollInterval = $0 }
+                    )) {
+                        ForEach(1...10, id: \.self) { second in
+                            Text("\(second)秒").tag(second)
+                        }
+                    }
+                }
+            }
+            
             Section("一般設定") {
                 Toggle("読了後に自動削除", isOn: Binding(
                     get: { viewModel.autoDeleteAfterRead },
@@ -565,10 +582,38 @@ final class ReaderViewModel {
         didSet { UserDefaults.standard.set(autoDeleteAfterRead, forKey: "autoDeleteAfterRead") }
     }
     
+    var isAutoScrollEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(isAutoScrollEnabled, forKey: "isAutoScrollEnabled")
+            handleAutoScrollStateChange()
+        }
+    }
+    
+    var autoScrollInterval: Int {
+        didSet {
+            UserDefaults.standard.set(autoScrollInterval, forKey: "autoScrollInterval")
+            if isAutoScrolling {
+                resetAutoScrollTimer()
+            }
+        }
+    }
+    
     // MARK: - State
     
-    var currentPage: Int
-    var showUI: Bool = true
+    var currentPage: Int {
+        didSet {
+            if isAutoScrollEnabled && !showUI {
+                resetAutoScrollTimer()
+            }
+        }
+    }
+    
+    var showUI: Bool = true {
+        didSet {
+            handleAutoScrollStateChange()
+        }
+    }
+    
     var isLandscape: Bool = false {
         didSet { 
             recalculateCurrentPage()
@@ -588,6 +633,10 @@ final class ReaderViewModel {
     private(set) var nextComic: LocalComic?
     private(set) var nextDriveItem: DriveItem?
     private(set) var widePageIndices: Set<Int> = []
+    
+    // 自動スクロール実行中ステータスとタスク
+    var isAutoScrolling: Bool = false
+    private var autoScrollTask: Task<Void, Never>?
     
     private var checkNextVolumeTask: Task<Void, Never>?
     private var scanWidePagesTask: Task<Void, Never>?
@@ -615,6 +664,10 @@ final class ReaderViewModel {
         self.isSpreadGapRemoved = UserDefaults.standard.object(forKey: "isSpreadGapRemoved") as? Bool ?? true
         self.autoDeleteAfterRead = UserDefaults.standard.bool(forKey: "autoDeleteAfterRead")
         
+        self.isAutoScrollEnabled = UserDefaults.standard.bool(forKey: "isAutoScrollEnabled")
+        let intervalVal = UserDefaults.standard.integer(forKey: "autoScrollInterval")
+        self.autoScrollInterval = intervalVal > 0 ? intervalVal : 5
+        
         // 初期ページの見開き位置への調整
         recalculateCurrentPage()
         
@@ -636,9 +689,57 @@ final class ReaderViewModel {
     }
     
     func cleanup() {
+        stopAutoScroll()
         checkNextVolumeTask?.cancel()
         scanWidePagesTask?.cancel()
         suggestionTask?.cancel()
+    }
+    
+    // MARK: - Auto Scroll Actions
+    
+    func handleAutoScrollStateChange() {
+        if isAutoScrollEnabled && !showUI {
+            startAutoScroll()
+        } else {
+            stopAutoScroll()
+        }
+    }
+    
+    func startAutoScroll() {
+        stopAutoScroll()
+        guard isAutoScrollEnabled else { return }
+        isAutoScrolling = true
+        
+        autoScrollTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled && self.isAutoScrolling {
+                // `autoScrollInterval` 秒待つ
+                try? await Task.sleep(nanoseconds: UInt64(self.autoScrollInterval) * 1_000_000_000)
+                guard !Task.isCancelled && self.isAutoScrolling else { break }
+                
+                // 最終ページに到達している場合
+                let lastIndex = self.pageIndices.last ?? 0
+                if self.currentPage >= lastIndex {
+                    // 次の巻サジェストが表示されるはずなので自動スクロールを止める
+                    self.stopAutoScroll()
+                    break
+                }
+                
+                self.goToNextPage()
+            }
+        }
+    }
+    
+    func stopAutoScroll() {
+        isAutoScrolling = false
+        autoScrollTask?.cancel()
+        autoScrollTask = nil
+    }
+    
+    func resetAutoScrollTimer() {
+        if isAutoScrollEnabled && !showUI {
+            startAutoScroll()
+        }
     }
     
     private func scanWidePages() async {

--- a/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
+++ b/GD-MangaReader/GD-MangaReader/Views/ReaderView.swift
@@ -628,14 +628,18 @@ final class ReaderViewModel {
         }
     }
     
-    var showNextVolumeSuggestion: Bool = false
+    var showNextVolumeSuggestion: Bool = false {
+        didSet {
+            handleAutoScrollStateChange()
+        }
+    }
     var isPreparingNextVolume: Bool = false
     private(set) var nextComic: LocalComic?
     private(set) var nextDriveItem: DriveItem?
     private(set) var widePageIndices: Set<Int> = []
     
     // 自動スクロール実行中ステータスとタスク
-    var isAutoScrolling: Bool = false
+    private(set) var isAutoScrolling: Bool = false
     private var autoScrollTask: Task<Void, Never>?
     
     private var checkNextVolumeTask: Task<Void, Never>?
@@ -698,7 +702,7 @@ final class ReaderViewModel {
     // MARK: - Auto Scroll Actions
     
     func handleAutoScrollStateChange() {
-        if isAutoScrollEnabled && !showUI {
+        if isAutoScrollEnabled && !showUI && !showNextVolumeSuggestion {
             startAutoScroll()
         } else {
             stopAutoScroll()
@@ -707,14 +711,15 @@ final class ReaderViewModel {
     
     func startAutoScroll() {
         stopAutoScroll()
-        guard isAutoScrollEnabled else { return }
+        guard isAutoScrollEnabled && !showNextVolumeSuggestion else { return }
         isAutoScrolling = true
         
         autoScrollTask = Task { [weak self] in
             guard let self else { return }
             while !Task.isCancelled && self.isAutoScrolling {
                 // `autoScrollInterval` 秒待つ
-                try? await Task.sleep(nanoseconds: UInt64(self.autoScrollInterval) * 1_000_000_000)
+                let safeInterval = max(1, self.autoScrollInterval)
+                try? await Task.sleep(nanoseconds: UInt64(safeInterval) * 1_000_000_000)
                 guard !Task.isCancelled && self.isAutoScrolling else { break }
                 
                 // 最終ページに到達している場合


### PR DESCRIPTION
漫画閲覧画面（ReaderView）に対して、自動スクロール（自動ページ送り）機能を追加しました。

### 主な対応内容
1. **自動スクロールタイマーの実装**
   - 設定された時間（1秒〜10秒）ごとに自動でページがめくられるよう、Swift Concurrencyの `Task` によるタイマーロジックを実装。
   - `currentPage` が更新されたとき（手動・自動問わず）にタイマーをリセットし、新たなページが表示された瞬間から再カウントするように制御。
   - 画面中央タップ等でメニュー（UIオーバーレイ）が表示されている間は自動スクロールを一時停止し、非表示になると再開する親切設計。
   - 最終ページに到達して次の巻の案内ダイアログが表示された際も、自動的にタイマーを停止します。

2. **見開き表示（Spread Mode）への考慮**
   - 自動スクロールのページ送りアクションとして、既存の見開きインデックス配列（`pageIndices`）に基づく `goToNextPage()` を呼び出すことで、見開き時は2ページずつ正しく進むように考慮。

3. **設定UIの追加**
   - ギアアイコンから開く設定メニュー内に「自動スクロール」セクションを追加。トグルによるON/OFFと、有効時に1秒〜10秒の間隔を秒単位で選べる Picker を配置。

4. **レビュー指摘に基づくリファクタリング**
   - メモリリーク防止のため、Task内を `[weak self]` キャプチャに変更。
   - `ReaderViewModel` クラス全体の `@MainActor` 属性に依拠し、冗長な `MainActor.run` を省いた最適化を実施。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 設定メニューに「自動スクロール」セクションを追加し、ON/OFFを切り替え可能にしました。
  * 有効時のみスクロール間隔（1〜10秒）を指定できます。保存設定も反映されます。
* **変更**
  * 表示状態やページ進行に応じて自動スクロールの開始/停止を制御し、最終ページ到達時は自動停止します。
* **変更**
  * iOSテストで利用するシミュレータ端末を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->