### PR TITLE
⚡ Bolt: Cache DriveItem displayName parsing for smoother library scrolling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-07-09 - Filter Before Sorting in LibraryViewModel
 **Learning:** Found a classic performance bottleneck where `items` are sorted first (O(N log N)) and then filtered by `searchText` (O(N)). When users type in a search box, doing this on every keystroke for large folders (like a root folder with hundreds/thousands of archives) can cause main thread hitching.
 **Action:** Filter the array first based on `searchText`, and only apply the expensive sort (`localizedStandardCompare`) on the resulting subset. This reduces the time complexity to O(N) + O(K log K) where K is the number of matched items, providing a measurable UI responsiveness boost when searching.
+
+## 2024-07-16 - Cache Regex Parsing Result in Stored Property for SwiftUI Views
+**Learning:** In SwiftUI, `LazyVGrid` and `LazyVStack` will re-evaluate view models during scrolling. If a model property is a computed property that executes complex Regular Expressions (like parsing display names with strings combinations), it will cause significant stutter during fast scrolling because those Regexes compile and run repeatedly on the UI thread for every view cell appearing/disappearing.
+**Action:** Replaced the computed property `displayName: MangaDisplayName` in `DriveItem` with a stored property and initialized it via a custom initializer `init(...)`. This shifts the expensive string parsing and regex matching to the time of fetching/decoding the items, which often happens off the main thread or at least only once per item, drastically reducing CPU overhead during view rendering.

--- a/GD-MangaReader/GD-MangaReader/Models/DriveItem.swift
+++ b/GD-MangaReader/GD-MangaReader/Models/DriveItem.swift
@@ -37,6 +37,50 @@ struct DriveItem: Identifiable, Hashable, Sendable {
     /// 画像の高さ（オプション）
     let height: Int?
     
+    /// 表示用に分解した名前（アーカイブは拡張子を除いてから解析する）
+    /// 以前はComputed Propertyだったが、スクロール時の再レンダリングのたびに
+    /// 重い正規表現処理が走るのを防ぐため、初期化時に1度だけ計算するStored Propertyに変更
+    let displayName: MangaDisplayName
+
+    // MARK: - Initialization
+
+    init(
+        id: String,
+        name: String,
+        mimeType: String,
+        size: Int64?,
+        thumbnailURL: URL?,
+        parentId: String?,
+        createdTime: Date?,
+        modifiedTime: Date?,
+        width: Int?,
+        height: Int?
+    ) {
+        self.id = id
+        self.name = name
+        self.mimeType = mimeType
+        self.size = size
+        self.thumbnailURL = thumbnailURL
+        self.parentId = parentId
+        self.createdTime = createdTime
+        self.modifiedTime = modifiedTime
+        self.width = width
+        self.height = height
+
+        // isArchiveと同等の判定ロジック（selfを参照できないためローカルで判定）
+        let ext = (name as NSString).pathExtension.lowercased()
+        let isArchiveType = Config.SupportedFormats.archiveExtensions.contains(ext) ||
+            mimeType == "application/zip" ||
+            mimeType == "application/x-zip-compressed" ||
+            mimeType == "application/x-rar-compressed" ||
+            mimeType == "application/vnd.rar" ||
+            mimeType == "application/x-cbz" ||
+            mimeType == "application/x-cbr"
+
+        let base = isArchiveType ? (name as NSString).deletingPathExtension : name
+        self.displayName = MangaDisplayName(parsing: base)
+    }
+
     // MARK: - Computed Properties
     
     /// フォルダかどうか
@@ -167,30 +211,24 @@ struct MangaDisplayName: Hashable, Sendable {
     }
 }
 
-extension DriveItem {
-    /// 表示用に分解した名前（アーカイブは拡張子を除いてから解析する）
-    var displayName: MangaDisplayName {
-        let base = isArchive ? (name as NSString).deletingPathExtension : name
-        return MangaDisplayName(parsing: base)
-    }
-}
-
 // MARK: - LocalComic Extension
 
 extension DriveItem {
     /// LocalComicからDriveItemオブジェクトを生成するマッピングイニシャライザ
     /// - Parameter localComic: ダウンロード済みの漫画データ
     init(from localComic: LocalComic) {
-        self.id = localComic.driveFileId
-        self.name = localComic.title
-        self.mimeType = "application/zip" // 一括アーカイブを模倣
-        self.size = localComic.originalFileSize
-        self.thumbnailURL = localComic.imagePaths.first // ローカルの絶対URLをサムネイルとして使用
-        self.parentId = nil
-        self.createdTime = localComic.downloadedAt
-        self.modifiedTime = localComic.lastReadAt
-        self.width = nil
-        self.height = nil
+        self.init(
+            id: localComic.driveFileId,
+            name: localComic.title,
+            mimeType: "application/zip", // 一括アーカイブを模倣
+            size: localComic.originalFileSize,
+            thumbnailURL: localComic.imagePaths.first, // ローカルの絶対URLをサムネイルとして使用
+            parentId: nil,
+            createdTime: localComic.downloadedAt,
+            modifiedTime: localComic.lastReadAt,
+            width: nil,
+            height: nil
+        )
     }
 }
 

--- a/patch_mock.patch
+++ b/patch_mock.patch
@@ -1,0 +1,26 @@
+--- GD-MangaReader/GD-MangaReader/Models/DriveItem.swift
++++ GD-MangaReader/GD-MangaReader/Models/DriveItem.swift
+@@ -237,7 +237,8 @@
+         createdTime: Date(),
+         modifiedTime: Date(),
+         width: nil,
+         height: nil
+     )
+
+     static let mockZipFile = DriveItem(
+@@ -248,7 +249,8 @@
+         createdTime: Date(),
+         modifiedTime: Date(),
+         width: nil,
+         height: nil
+     )
+
+     static let mockRarFile = DriveItem(
+@@ -259,7 +261,8 @@
+         createdTime: Date(),
+         modifiedTime: Date(),
+         width: nil,
+         height: nil
+     )
+
+     static let mockItems: [DriveItem] = [


### PR DESCRIPTION
Replaced `displayName` from a computed property to a cached stored property in `DriveItem` to prevent expensive regex parsing on every scroll render in SwiftUI Grid/List views.

---
*PR created automatically by Jules for task [6303326134509310503](https://jules.google.com/task/6303326134509310503) started by @miyatsuko10004*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * 漫画タイトルの解析処理を表示時ではなくデータ読み込み時に実行するよう改善しました。
  * ファイル一覧や漫画名の表示がよりスムーズになることが期待されます。

* **品質改善**
  * ファイル情報の初期化処理を整理し、表示名の一貫性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->